### PR TITLE
feat(seo): regions index + detail pages + sitemap (Week 1)

### DIFF
--- a/src/app/actions/crew.ts
+++ b/src/app/actions/crew.ts
@@ -483,11 +483,7 @@ export async function updateCrewByToken(
   // 8. Cache invalidation — map page and home rely on this data. The tag
   // invalidates the `unstable_cache`-wrapped getCrews data layer; the path
   // calls bust the per-route render cache for navigation freshness.
-  revalidateTag(CREWS_CACHE_TAG);
-  revalidatePath("/");
-  revalidatePath("/map");
-  revalidatePath("/crew/list");
-  revalidatePath(`/crew/edit/${crewId}`);
+  await revalidateCrewsCache(crewId);
 
   // 9. Discord notification with diff. Fire-and-forget.
   notifyCrewEdit({
@@ -612,9 +608,7 @@ export async function updateCrewVisibility(
       return { success: false, error: error.message };
     }
 
-    revalidateTag(CREWS_CACHE_TAG);
-    revalidatePath("/");
-    revalidatePath("/map");
+    await revalidateCrewsCache(crewId);
     return { success: true };
   } catch (err) {
     console.error("크루 가시성 업데이트 실패:", err);
@@ -641,6 +635,9 @@ export async function revalidateCrewsCache(
   revalidatePath("/");
   revalidatePath("/map");
   revalidatePath("/crew/list");
+  revalidatePath("/regions");
+  revalidatePath("/regions/[code]", "page");
+  revalidatePath("/sitemap.xml");
   if (crewId) {
     revalidatePath(`/crew/${crewId}`);
     revalidatePath(`/crew/edit/${crewId}`);
@@ -691,9 +688,7 @@ export async function deleteCrew(
       return { success: false, error: deleteError.message };
     }
 
-    revalidateTag(CREWS_CACHE_TAG);
-    revalidatePath("/");
-    revalidatePath("/map");
+    await revalidateCrewsCache(crewId);
     return { success: true };
   } catch (err) {
     console.error("크루 삭제 실패:", err);

--- a/src/app/actions/crew.ts
+++ b/src/app/actions/crew.ts
@@ -47,6 +47,9 @@ export async function notifyCrewRegistration(crew: {
     // New crew arrives as is_visible=false → not yet in the public list,
     // but tag-invalidate anyway so any in-flight cached read is refreshed
     // when an admin later approves the crew.
+    // 등록 시점에는 is_visible=false라 공개 페이지(지역/리스트/sitemap)에 없으므로
+    // 경로 revalidate는 불필요. revalidateCrewsCache 헬퍼를 부르지 않는 이유.
+    // 단, 관리자가 나중에 승인할 때 in-flight 캐시 read가 신선해지도록 태그만 무효화.
     revalidateTag(CREWS_CACHE_TAG);
   } catch (err) {
     console.error("Unexpected error setting is_visible=false:", err);

--- a/src/app/menu/page.tsx
+++ b/src/app/menu/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { PlusCircle, MessageCircle, ChevronRight } from "lucide-react";
+import { PlusCircle, MessageCircle, MapPin, ChevronRight } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { CSS_VARIABLES } from "@/lib/constants";
 import {
@@ -18,6 +18,7 @@ interface MenuLinkRow {
 
 const PRIMARY_LINKS: MenuLinkRow[] = [
   { title: "크루 등록", en: "REGISTER", path: "/register" },
+  { title: "지역별 보기", en: "REGIONS", path: "/regions" },
   {
     title: "문의 및 건의",
     en: "CONTACT",
@@ -74,6 +75,8 @@ export default function MenuPage() {
               <div className="w-9 h-9 rounded-[4px] bg-cart-paper border border-cart-rule flex items-center justify-center flex-shrink-0">
                 {item.en === "REGISTER" ? (
                   <PlusCircle className="w-4 h-4 text-[hsl(var(--lime))]" strokeWidth={1.6} />
+                ) : item.en === "REGIONS" ? (
+                  <MapPin className="w-4 h-4 text-[hsl(var(--lime))]" strokeWidth={1.6} />
                 ) : (
                   <MessageCircle className="w-4 h-4 text-[hsl(var(--lime))]" strokeWidth={1.6} />
                 )}

--- a/src/app/regions/[code]/loading.tsx
+++ b/src/app/regions/[code]/loading.tsx
@@ -1,0 +1,17 @@
+import { KickerLabel } from "@/components/design/cartographic";
+import { Loader2 } from "lucide-react";
+import { CSS_VARIABLES } from "@/lib/constants";
+
+export default function RegionLoading() {
+  return (
+    <div
+      className="flex flex-col items-center justify-center min-h-[60vh] bg-background"
+      style={{ paddingTop: CSS_VARIABLES.HEADER_PADDING }}
+    >
+      <Loader2 className="w-5 h-5 text-[hsl(var(--lime))] animate-spin" />
+      <KickerLabel tone="muted" className="mt-3 tracking-[0.2em]">
+        · LOADING REGION
+      </KickerLabel>
+    </div>
+  );
+}

--- a/src/app/regions/[code]/page.tsx
+++ b/src/app/regions/[code]/page.tsx
@@ -92,7 +92,12 @@ export default async function RegionDetailPage(
       ) : (
         <div className="border-t border-b border-cart-rule">
           {crews.map((crew, i) => (
-            <RegionCrewRow key={crew.id} crew={crew} rank={i + 1} />
+            <RegionCrewRow
+              key={crew.id}
+              crew={crew}
+              rank={i + 1}
+              regionCode={code as RegionCode}
+            />
           ))}
         </div>
       )}

--- a/src/app/regions/[code]/page.tsx
+++ b/src/app/regions/[code]/page.tsx
@@ -1,0 +1,109 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { ChevronLeft } from "lucide-react";
+import { CartographicHeader, KickerLabel } from "@/components/design/cartographic";
+import { RegionCrewRow } from "@/components/regions/RegionCrewRow";
+import {
+  getAllRegionCodes,
+  getCrewsByRegion,
+  getRegionDef,
+  type RegionCode,
+} from "@/lib/server/regions";
+import { CSS_VARIABLES } from "@/lib/constants";
+
+export const revalidate = 600;
+
+export async function generateStaticParams() {
+  return getAllRegionCodes().map((code) => ({ code }));
+}
+
+export async function generateMetadata(
+  { params }: { params: Promise<{ code: string }> }
+): Promise<Metadata> {
+  const { code } = await params;
+  const def = getRegionDef(code);
+  if (!def) return {};
+  const crews = await getCrewsByRegion(code as RegionCode);
+  const title = `${def.name} 러닝크루 ${crews.length}곳`;
+  const description = `${def.name}에서 활동 중인 러닝크루를 한눈에. ${def.blurb}.`;
+  return {
+    title,
+    description,
+    alternates: { canonical: `/regions/${code}` },
+    openGraph: {
+      title: `${title} | 런하우스`,
+      description,
+      url: `/regions/${code}`,
+      type: "website",
+    },
+  };
+}
+
+export default async function RegionDetailPage(
+  { params }: { params: Promise<{ code: string }> }
+) {
+  const { code } = await params;
+  const def = getRegionDef(code);
+  if (!def) notFound();
+
+  const crews = await getCrewsByRegion(code as RegionCode);
+
+  return (
+    <div
+      className="flex flex-col min-h-screen bg-background"
+      style={{ paddingTop: CSS_VARIABLES.HEADER_PADDING }}
+    >
+      <div className="px-[18px] pt-4 pb-3">
+        <Link
+          href="/regions"
+          className="inline-flex items-center gap-1 font-mono text-[10px] tracking-[0.18em] text-cart-ink-60 hover:text-[hsl(var(--lime))] mb-2"
+        >
+          <ChevronLeft className="w-3 h-3" /> ALL REGIONS
+        </Link>
+        {/* kicker: leading · 는 CartographicHeader가 자동으로 붙이므로 생략 */}
+        <CartographicHeader
+          kicker={`REGION · ${def.name.toUpperCase()}`}
+          title={`${def.name} 러닝크루 ${crews.length}곳`}
+        />
+        <KickerLabel tone="muted" className="tracking-[0.18em] mt-2">
+          {def.blurb}
+        </KickerLabel>
+      </div>
+
+      {crews.length === 0 ? (
+        <div className="px-[18px] py-10 text-center">
+          <KickerLabel tone="muted" className="tracking-[0.18em]">
+            · 등록된 크루가 없습니다 ·
+          </KickerLabel>
+          <div className="mt-4">
+            {/* LimeCTA는 button 전용이므로 Link로 감싸 CTA 스타일 구현 */}
+            <Link
+              href="/register"
+              className="w-full flex items-center justify-between px-5 py-4 bg-[hsl(var(--lime))] text-[hsl(var(--lime-foreground))] rounded-[4px] active:scale-[0.98] transition-transform"
+            >
+              <span className="font-display text-[15px] font-bold">우리 크루 등록하기</span>
+              <span className="font-mono text-[10px] font-semibold tracking-[0.12em]">
+                REGISTER →
+              </span>
+            </Link>
+          </div>
+        </div>
+      ) : (
+        <div className="border-t border-b border-cart-rule">
+          {crews.map((crew, i) => (
+            <RegionCrewRow key={crew.id} crew={crew} rank={i + 1} />
+          ))}
+        </div>
+      )}
+
+      <div className="px-[18px] py-6 text-[11px] text-cart-ink-60 leading-relaxed">
+        주소의 시·도 표기를 기준으로 자동 분류합니다. 본인 크루의 분류가 잘못되어 있으면{" "}
+        <Link href="/register" className="underline text-[hsl(var(--lime))]">
+          등록 페이지
+        </Link>
+        에서 정확한 주소로 수정 요청을 보낼 수 있습니다.
+      </div>
+    </div>
+  );
+}

--- a/src/app/regions/page.tsx
+++ b/src/app/regions/page.tsx
@@ -28,6 +28,7 @@ export default async function RegionsIndexPage() {
       style={{ paddingTop: CSS_VARIABLES.HEADER_PADDING }}
     >
       <div className="px-[18px] pt-4 pb-3">
+        {/* kicker: leading · 는 CartographicHeader가 자동으로 붙이므로 여기엔 생략 */}
         <CartographicHeader
           kicker="DISCOVER · 7 REGIONS"
           title="지역별 러닝크루"

--- a/src/app/regions/page.tsx
+++ b/src/app/regions/page.tsx
@@ -1,0 +1,47 @@
+import type { Metadata } from "next";
+import { CartographicHeader, KickerLabel } from "@/components/design/cartographic";
+import { RegionIndexList } from "@/components/regions/RegionIndexList";
+import { getRegionSummaries } from "@/lib/server/regions";
+import { CSS_VARIABLES } from "@/lib/constants";
+
+export const revalidate = 600;
+
+export const metadata: Metadata = {
+  title: "지역별 러닝크루",
+  description: "전국 7개 광역 단위로 등록된 러닝크루를 찾아보세요. 서울·경기·강원·경상·전라·충청·제주.",
+  alternates: { canonical: "/regions" },
+  openGraph: {
+    title: "지역별 러닝크루 | 런하우스",
+    description: "전국 7개 광역의 러닝크루를 한눈에.",
+    url: "/regions",
+    type: "website",
+  },
+};
+
+export default async function RegionsIndexPage() {
+  const summaries = await getRegionSummaries();
+  const total = summaries.reduce((acc, s) => acc + s.count, 0);
+
+  return (
+    <div
+      className="flex flex-col min-h-screen bg-background"
+      style={{ paddingTop: CSS_VARIABLES.HEADER_PADDING }}
+    >
+      <div className="px-[18px] pt-4 pb-3">
+        <CartographicHeader
+          kicker="DISCOVER · 7 REGIONS"
+          title="지역별 러닝크루"
+        />
+        <KickerLabel tone="muted" className="tracking-[0.18em] mt-2">
+          전국 {total.toString().padStart(3, "0")} 곳 · 광역 단위 집계
+        </KickerLabel>
+      </div>
+
+      <RegionIndexList rows={summaries} />
+
+      <div className="px-[18px] py-6 text-[11px] text-cart-ink-60 leading-relaxed">
+        주소의 시·도 표기를 기준으로 자동 분류합니다. 매장 정보가 갱신되면 약 1분 안에 반영됩니다.
+      </div>
+    </div>
+  );
+}

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,21 @@
+// src/app/robots.ts
+import type { MetadataRoute } from "next";
+
+const BASE_URL =
+  process.env.NEXT_PUBLIC_APP_URL ||
+  process.env.NEXT_PUBLIC_SITE_URL ||
+  "https://running-crew-map.vercel.app";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+        disallow: ["/admin", "/admin/", "/api/", "/crew/edit/"],
+      },
+    ],
+    sitemap: `${BASE_URL}/sitemap.xml`,
+    host: BASE_URL,
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,30 @@
+// src/app/sitemap.ts
+import type { MetadataRoute } from "next";
+import { REGION_DEFS } from "@/lib/server/regions";
+
+const BASE_URL =
+  process.env.NEXT_PUBLIC_APP_URL ||
+  process.env.NEXT_PUBLIC_SITE_URL ||
+  "https://running-crew-map.vercel.app";
+
+export const revalidate = 600;
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const now = new Date();
+  const staticRoutes: MetadataRoute.Sitemap = [
+    { url: `${BASE_URL}/`,          lastModified: now, changeFrequency: "daily",   priority: 1.0 },
+    { url: `${BASE_URL}/map`,       lastModified: now, changeFrequency: "daily",   priority: 0.9 },
+    { url: `${BASE_URL}/crew/list`, lastModified: now, changeFrequency: "daily",   priority: 0.8 },
+    { url: `${BASE_URL}/regions`,   lastModified: now, changeFrequency: "weekly",  priority: 0.8 },
+    { url: `${BASE_URL}/notice`,    lastModified: now, changeFrequency: "weekly",  priority: 0.5 },
+    { url: `${BASE_URL}/register`,  lastModified: now, changeFrequency: "monthly", priority: 0.5 },
+  ];
+  const regionRoutes: MetadataRoute.Sitemap = REGION_DEFS.map((d) => ({
+    url: `${BASE_URL}/regions/${d.code}`,
+    lastModified: now,
+    changeFrequency: "daily",
+    priority: 0.7,
+  }));
+  // Week 2: /crew/[id] 단독 페이지가 생기면 visible crew URL을 추가한다.
+  return [...staticRoutes, ...regionRoutes];
+}

--- a/src/components/regions/RegionCrewRow.tsx
+++ b/src/components/regions/RegionCrewRow.tsx
@@ -1,0 +1,43 @@
+import Image from "next/image";
+import Link from "next/link";
+import type { Crew } from "@/lib/types/crew";
+
+export function RegionCrewRow({ crew, rank }: { crew: Crew; rank: number }) {
+  const area =
+    crew.location.main_address?.split(" ").slice(0, 2).join(" ") ||
+    crew.location.address?.split(" ").slice(0, 2).join(" ") ||
+    "—";
+  return (
+    <Link
+      // Week 2에 /crew/[id] 단독 페이지가 생기면 그곳으로 교체.
+      href={`/crew/list#crew-${crew.id}`}
+      className="flex items-center gap-3 py-3.5 px-[18px] border-t border-cart-rule first:border-t-0 active:bg-white/[0.02] focus-visible:outline focus-visible:outline-1 focus-visible:outline-[hsl(var(--lime))] focus-visible:-outline-offset-1"
+    >
+      <div className="w-8 font-mono text-[11px] tracking-[0.05em] text-cart-ink-60 tabular-nums">
+        {String(rank).padStart(2, "0")}
+      </div>
+      {crew.logo_image ? (
+        <div className="relative flex-shrink-0 w-9 h-9 rounded-[4px] overflow-hidden border border-cart-rule bg-cart-paper">
+          <Image
+            src={crew.logo_image}
+            alt={crew.name}
+            width={36}
+            height={36}
+            className="object-cover w-full h-full"
+            sizes="36px"
+          />
+        </div>
+      ) : (
+        <div className="flex flex-shrink-0 justify-center items-center w-9 h-9 rounded-[4px] bg-cart-paper border border-cart-rule font-display text-[14px] font-semibold text-[hsl(var(--lime))]">
+          {crew.name.charAt(0)}
+        </div>
+      )}
+      <div className="flex-1 min-w-0">
+        <div className="text-[14px] font-semibold text-cart-ink truncate">{crew.name}</div>
+        <div className="font-mono text-[10px] tracking-[0.04em] text-cart-ink-60 truncate mt-0.5">
+          {area}
+        </div>
+      </div>
+    </Link>
+  );
+}

--- a/src/components/regions/RegionCrewRow.tsx
+++ b/src/components/regions/RegionCrewRow.tsx
@@ -1,8 +1,17 @@
 import Image from "next/image";
 import Link from "next/link";
 import type { Crew } from "@/lib/types/crew";
+import type { RegionCode } from "@/lib/server/regions";
 
-export function RegionCrewRow({ crew, rank }: { crew: Crew; rank: number }) {
+export function RegionCrewRow({
+  crew,
+  rank,
+  regionCode,
+}: {
+  crew: Crew;
+  rank: number;
+  regionCode: RegionCode;
+}) {
   const area =
     crew.location.main_address?.split(" ").slice(0, 2).join(" ") ||
     crew.location.address?.split(" ").slice(0, 2).join(" ") ||
@@ -10,7 +19,8 @@ export function RegionCrewRow({ crew, rank }: { crew: Crew; rank: number }) {
   return (
     <Link
       // Week 2에 /crew/[id] 단독 페이지가 생기면 그곳으로 교체.
-      href={`/crew/list#crew-${crew.id}`}
+      // ?region= 쿼리로 list 페이지가 같은 region에 필터된 상태로 열리도록.
+      href={`/crew/list?region=${regionCode}#crew-${crew.id}`}
       className="flex items-center gap-3 py-3.5 px-[18px] border-t border-cart-rule first:border-t-0 active:bg-white/[0.02] focus-visible:outline focus-visible:outline-1 focus-visible:outline-[hsl(var(--lime))] focus-visible:-outline-offset-1"
     >
       <div className="w-8 font-mono text-[11px] tracking-[0.05em] text-cart-ink-60 tabular-nums">

--- a/src/components/regions/RegionIndexList.tsx
+++ b/src/components/regions/RegionIndexList.tsx
@@ -1,0 +1,33 @@
+import Link from "next/link";
+import { KickerLabel } from "@/components/design/cartographic";
+import type { RegionSummary } from "@/lib/server/regions";
+
+export function RegionIndexList({ rows }: { rows: ReadonlyArray<RegionSummary> }) {
+  return (
+    <ul className="divide-y divide-cart-rule border-t border-b border-cart-rule">
+      {rows.map((row, idx) => (
+        <li key={row.code}>
+          <Link
+            href={`/regions/${row.code}`}
+            className="flex items-center gap-3 px-[18px] py-3.5 active:bg-white/[0.02] focus:outline-none focus:bg-white/[0.02]"
+          >
+            <div className="w-8 font-mono text-[11px] tracking-[0.05em] text-cart-ink-60 tabular-nums">
+              {String(idx + 1).padStart(2, "0")}
+            </div>
+            <div className="flex-1 min-w-0">
+              <div className="text-[14px] font-semibold text-cart-ink truncate">
+                {row.name}
+              </div>
+              <div className="font-mono text-[10px] tracking-[0.04em] text-cart-ink-60 truncate mt-0.5">
+                {row.blurb}
+              </div>
+            </div>
+            <KickerLabel tone={row.count > 0 ? "lime" : "muted"} className="tabular-nums">
+              {String(row.count).padStart(2, "0")} 곳
+            </KickerLabel>
+          </Link>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/components/regions/RegionIndexList.tsx
+++ b/src/components/regions/RegionIndexList.tsx
@@ -9,7 +9,7 @@ export function RegionIndexList({ rows }: { rows: ReadonlyArray<RegionSummary> }
         <li key={row.code}>
           <Link
             href={`/regions/${row.code}`}
-            className="flex items-center gap-3 px-[18px] py-3.5 active:bg-white/[0.02] focus:outline-none focus:bg-white/[0.02]"
+            className="flex items-center gap-3 px-[18px] py-3.5 active:bg-white/[0.02] focus-visible:outline focus-visible:outline-1 focus-visible:outline-[hsl(var(--lime))] focus-visible:-outline-offset-1"
           >
             <div className="w-8 font-mono text-[11px] tracking-[0.05em] text-cart-ink-60 tabular-nums">
               {String(idx + 1).padStart(2, "0")}

--- a/src/lib/server/regions.ts
+++ b/src/lib/server/regions.ts
@@ -43,12 +43,23 @@ export function getAllRegionCodes(): RegionCode[] {
   return REGION_DEFS.map((d) => d.code);
 }
 
+/**
+ * Look up a region definition by code.
+ *
+ * `code` is intentionally `string` (not `RegionCode`): this is the gateway
+ * used by route handlers receiving raw URL params, which arrive as `string`.
+ * Returns `undefined` for unknown codes — callers should branch on that
+ * (e.g. call `notFound()` in a page) instead of pre-validating.
+ */
 export function getRegionDef(code: string): RegionDef | undefined {
   return REGION_DEFS.find((d) => d.code === code);
 }
 
 /** main_address 우선으로 크루 1개의 지역 코드를 결정. 매칭 실패 시 null. */
 export function regionCodeForCrew(crew: Crew): RegionCode | null {
+  // 주의: main_address 우선. filterCrewsByRegion(region-utils.ts)은
+  // address(=detail_address||main_address) 우선이라 상세주소가 다른 시/도로
+  // 시작하는 데이터에서 잘못 분류됨 — 이 함수는 그 버그를 회피.
   const address = crew.location.main_address || crew.location.address || "";
   if (!address) return null;
   const firstPart = address.split(" ")[0] || "";

--- a/src/lib/server/regions.ts
+++ b/src/lib/server/regions.ts
@@ -1,0 +1,84 @@
+// src/lib/server/regions.ts
+import "server-only";
+import { cache } from "react";
+import { getCrews } from "./crews";
+import { REGION_KEYWORDS } from "@/lib/utils/region-utils";
+import type { Crew } from "@/lib/types/crew";
+
+export type RegionCode =
+  | "seoul"
+  | "gyeonggi"
+  | "gangwon"
+  | "gyeongsang"
+  | "jeolla"
+  | "chungcheong"
+  | "jeju";
+
+export interface RegionDef {
+  code: RegionCode;
+  /** 한국어 표시명 (예: "서울", "경상도") */
+  name: string;
+  /** 페이지 타이틀용 한 줄 설명 */
+  blurb: string;
+  /** 정적 미니맵용 중심 좌표 (Week 2부터 사용) */
+  center: { lat: number; lng: number };
+}
+
+export const REGION_DEFS: ReadonlyArray<RegionDef> = [
+  { code: "seoul",      name: "서울",   blurb: "한강과 도심 러닝 수요가 큰 지역",                       center: { lat: 37.5665, lng: 126.9780 } },
+  { code: "gyeonggi",   name: "경기",   blurb: "분당·판교·수원·일산 등 생활권 단위로 분포",            center: { lat: 37.4138, lng: 127.5183 } },
+  { code: "gangwon",    name: "강원",   blurb: "강릉·춘천·속초의 자연 러닝 코스",                       center: { lat: 37.8228, lng: 128.1555 } },
+  { code: "gyeongsang", name: "경상도", blurb: "부산·대구·울산을 중심으로 한 광역 러닝 씬",              center: { lat: 35.8714, lng: 128.6014 } },
+  { code: "jeolla",     name: "전라도", blurb: "광주·전주를 중심으로 한 지역 러닝 커뮤니티",             center: { lat: 35.1595, lng: 126.8526 } },
+  { code: "chungcheong",name: "충청도", blurb: "대전·세종·청주 도심형 러닝 크루",                       center: { lat: 36.3504, lng: 127.3845 } },
+  { code: "jeju",       name: "제주도", blurb: "여행형 러닝 수요가 큰 지역",                            center: { lat: 33.4996, lng: 126.5312 } },
+];
+
+export interface RegionSummary extends RegionDef {
+  /** is_visible=true 크루 중 이 지역으로 분류된 개수 */
+  count: number;
+}
+
+export function getAllRegionCodes(): RegionCode[] {
+  return REGION_DEFS.map((d) => d.code);
+}
+
+export function getRegionDef(code: string): RegionDef | undefined {
+  return REGION_DEFS.find((d) => d.code === code);
+}
+
+/** main_address 우선으로 크루 1개의 지역 코드를 결정. 매칭 실패 시 null. */
+export function regionCodeForCrew(crew: Crew): RegionCode | null {
+  const address = crew.location.main_address || crew.location.address || "";
+  if (!address) return null;
+  const firstPart = address.split(" ")[0] || "";
+
+  // 광주 동음이의 — "광주시"는 경기, "광주광역시"는 전라
+  if (firstPart === "광주시" || firstPart === "광주") {
+    if (address.includes("경기")) return "gyeonggi";
+    return "jeolla";
+  }
+
+  for (const code of getAllRegionCodes()) {
+    const keywords = REGION_KEYWORDS[code] ?? [];
+    if (keywords.some((kw) => firstPart.includes(kw))) {
+      return code;
+    }
+  }
+  return null;
+}
+
+export const getRegionSummaries = cache(async (): Promise<RegionSummary[]> => {
+  const crews = await getCrews();
+  const counts = new Map<RegionCode, number>();
+  for (const crew of crews) {
+    const code = regionCodeForCrew(crew);
+    if (code) counts.set(code, (counts.get(code) ?? 0) + 1);
+  }
+  return REGION_DEFS.map((def) => ({ ...def, count: counts.get(def.code) ?? 0 }));
+});
+
+export const getCrewsByRegion = cache(async (code: RegionCode): Promise<Crew[]> => {
+  const crews = await getCrews();
+  return crews.filter((c) => regionCodeForCrew(c) === code);
+});


### PR DESCRIPTION
## Summary

Week 1 of the **Regions SEO** roadmap (`docs/plans/2026-05-18-regions-seo-week-1.md`). Adds discoverable per-region pages so "서울 러닝크루", "제주 러닝크루" 같은 롱테일 검색에서 잡힐 정식 URL이 생긴다. 스키마 변경 0건 — 기존 `getCrews()` (`CREWS_CACHE_TAG`) 위에서 derive.

### What ships

- **`/regions`** — 7 광역 hairline 인덱스 (cartographic, ISR 10분, OG metadata).
- **`/regions/[code]`** — 지역 상세, `generateStaticParams`로 7개 정적 prerender (seoul, gyeonggi, gangwon, gyeongsang, jeolla, chungcheong, jeju). 잘못된 코드는 `notFound()`. 빈 지역은 등록 CTA.
- **`sitemap.xml` + `robots.txt`** — 정적 라우트 6개 + 7개 region 포함, `/admin` `/api` `/crew/edit` 색인 차단.
- **Cache contract 확장** — `revalidateCrewsCache` 헬퍼가 `/regions`, `/regions/[code]`, `/sitemap.xml`도 무효화하도록 확장하고 `updateCrewByToken`/`updateCrewVisibility`/`deleteCrew` 3개를 헬퍼로 DRY. 보너스로 토큰 편집·visibility 토글이 이제 `/crew/<id>`도 invalidate.
- **`/menu`에 "지역별 보기" 진입 행** — GSC 색인 lag 동안 사이트 내부 동선 확보.

### Design / 데이터 결정

- `main_address` 우선의 region 분류 (`src/lib/server/regions.ts:regionCodeForCrew`) — 기존 `filterCrewsByRegion`은 `address || main_address` 순서라 detail address가 다른 시/도로 시작하는 데이터에서 오분류. 새 함수는 그 버그를 회피하면서 client 경로(필터)는 기존 함수 그대로 유지. ([결정.md 2026-05-18 항목 참고])
- 크루 행 링크는 `/crew/list#crew-<id>` — Week 2에서 `/crew/[id]` 단독 페이지로 교체 예정.

### Week 2로 미룬 항목 (의도적)

- 동적 OG 이미지 (`opengraph-image.tsx`)
- `/crew/[id]` 단독 페이지 (현재 시트로만 열림 — SEO 누수)
- `LocalBusiness` / `Organization` JSON-LD
- `sitemap.xml`에 visible 크루 URL 추가

### Build verification

```
○ /regions                                  static  10m ISR
● /regions/[code]                           SSG × 7개 (seoul/gyeonggi/gangwon/gyeongsang/jeolla/chungcheong/jeju)
○ /robots.txt                               static
○ /sitemap.xml                              static  10m ISR
```

`npm run lint` warnings 2건 모두 PR 범위 밖 기존 코드(`crew/list/page.tsx:237`, `mbti/page.tsx:838`).

## Test plan

- [ ] `/regions` 로딩, 7개 region 행 + 카운트 표시
- [ ] `/regions/seoul` 로딩, 크루 리스트 표시
- [ ] `/regions/nonexistent` → 404
- [ ] `/sitemap.xml`에 7개 region URL 포함
- [ ] `/robots.txt`에 `/admin` `/api` `/crew/edit` Disallow + sitemap 참조
- [ ] `/menu` → "지역별 보기" 클릭 → `/regions` 이동
- [ ] 관리자 visibility 토글 후 60초 안에 `/regions/<해당 region>` 카운트 갱신
- [ ] (배포 후) GSC에 sitemap 제출 및 색인 등록 모니터링

## Subagent-driven execution

이 PR은 superpowers:subagent-driven-development 워크플로로 task 8개를 dispatch → spec review → quality review → fix-loop 사이클로 만들어졌습니다. 10개 commit (Task 1-7 + 폴리시 / 문서 fixes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)