### PR TITLE
feat: Vercel 이미지 비용 절감 + 매장/메뉴 UI 정합성 개선

### DIFF
--- a/migrations/2026-06-12-add-logo-thumb-url.sql
+++ b/migrations/2026-06-12-add-logo-thumb-url.sql
@@ -1,0 +1,44 @@
+-- Migration: Add logo_thumb_url column to crews and stores tables
+-- Date: 2026-06-12
+--
+-- Purpose:
+--   Adds a nullable `logo_thumb_url` (text) column to both the `crews` and
+--   `stores` tables. This column stores the public URL of a smaller,
+--   thumbnail-sized variant of the entity's logo image. Thumbnails are
+--   intended for use in list views, map markers, and other low-bandwidth
+--   contexts where the full-resolution `logo_image_url` / `logo_url` would
+--   be wasteful to load.
+--
+--   - crews.logo_thumb_url   : thumbnail companion to crews.logo_image_url
+--   - stores.logo_thumb_url  : thumbnail companion to stores.logo_url
+--
+--   The column is nullable because thumbnail generation may be performed
+--   lazily (e.g. backfilled by a worker) and existing rows will not have a
+--   thumbnail until their logo is re-processed.
+--
+-- Apply this migration manually via the Supabase SQL editor.
+-- This script is idempotent and safe to re-run.
+
+BEGIN;
+
+-- Crews: thumbnail variant of logo_image_url
+ALTER TABLE public.crews
+  ADD COLUMN IF NOT EXISTS logo_thumb_url text;
+
+COMMENT ON COLUMN public.crews.logo_thumb_url IS
+  'Public URL of the thumbnail-sized variant of the crew logo (companion to logo_image_url). Nullable; populated when a thumbnail has been generated.';
+
+-- Stores: thumbnail variant of logo_url
+ALTER TABLE public.stores
+  ADD COLUMN IF NOT EXISTS logo_thumb_url text;
+
+COMMENT ON COLUMN public.stores.logo_thumb_url IS
+  'Public URL of the thumbnail-sized variant of the store logo (companion to logo_url). Nullable; populated when a thumbnail has been generated.';
+
+COMMIT;
+
+-- Rollback (run manually if needed):
+-- BEGIN;
+--   ALTER TABLE public.crews  DROP COLUMN IF EXISTS logo_thumb_url;
+--   ALTER TABLE public.stores DROP COLUMN IF EXISTS logo_thumb_url;
+-- COMMIT;

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -61,8 +61,9 @@ const nextConfig = {
         hostname: "**.supabase.in",
       },
     ],
-    deviceSizes: [640, 750, 828, 1080, 1200, 1920, 2048, 3840],
-    imageSizes: [16, 32, 48, 64, 96, 128, 256, 384],
+    deviceSizes: [640, 828, 1200, 1920],
+    imageSizes: [40, 64, 128, 256],
+    minimumCacheTTL: 2678400,
   },
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,6 @@
         "@radix-ui/react-toggle-group": "^1.1.1",
         "@radix-ui/react-tooltip": "^1.1.6",
         "@serwist/next": "^9.5.4",
-        "@supabase/supabase-js": "^2.48.1",
         "@types/html2canvas": "^1.0.0",
         "@types/navermaps": "^3.7.8",
         "@types/uuid": "^10.0.0",
@@ -76,6 +75,7 @@
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
+        "@supabase/supabase-js": "^2.108.1",
         "@types/bcryptjs": "^2.4.6",
         "@types/node": "^20",
         "@types/react": "^19",
@@ -83,7 +83,9 @@
         "eslint": "^9",
         "eslint-config-next": "^15.5.12",
         "postcss": "^8",
+        "sharp": "^0.35.1",
         "tailwindcss": "^3.4.1",
+        "tsx": "^4.22.4",
         "typescript": "^5"
       }
     },
@@ -115,12 +117,455 @@
       "integrity": "sha512-LBrd7MiJZ9McsOgxqWX7AaxrDjcFVjWH/tIKJd7pnR7McaslGYOP1QmmiBXdJH/H/yLCT+rcQ7FaPBUxRGUtrg=="
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
-      "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.0.tgz",
+      "integrity": "sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg==",
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -346,63 +791,90 @@
       }
     },
     "node_modules/@img/colour": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.0.0.tgz",
-      "integrity": "sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==",
-      "optional": true,
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "devOptional": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
-      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "version": "0.35.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.1.tgz",
+      "integrity": "sha512-T15JRWOubQ3f5+GxnWeIvo47u5qV0M9HBgJhT+f2gE1e9e6OhR6K73Re52Hm80qWcu1DNb3GweKmpr/MnuP2Ow==",
       "cpu": [
         "arm64"
       ],
+      "dev": true,
+      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "darwin"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+        "@img/sharp-libvips-darwin-arm64": "1.3.0"
       }
     },
     "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
-      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "version": "0.35.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.1.tgz",
+      "integrity": "sha512-t1CPD0cr7XCHjwUj6tQ5MC0pCi866I+gUW6zbUX4aFPnKd1DFBtk0M+gWcjX8VeEzgfCNiSiNTVFZ6b7kvdbnQ==",
       "cpu": [
         "x64"
       ],
+      "dev": true,
+      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "darwin"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.2.4"
+        "@img/sharp-libvips-darwin-x64": "1.3.0"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.1.tgz",
+      "integrity": "sha512-MBSQXqNPThW9EcZ905H6N4sEdX5EwZEYzGx5EBq9ncDCGJALMiY1xPFJxNdzuB1iBjLOpIfxajM6YxdvwmQSLA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.1"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
-      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.0.tgz",
+      "integrity": "sha512-EKbmBKtyTH+GPFDRw2TgK2oV6hyxxlJVIar4hoTYSNmIwipgMFdxPQqR392GmfdsPGWga0mCFN1cCKjRb9cljw==",
       "cpu": [
         "arm64"
       ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "darwin"
@@ -412,12 +884,14 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
-      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.0.tgz",
+      "integrity": "sha512-Pl2OmOvrJ42adUllESxBsG54PfXLo1OYg9i3c5/5Ln/qJ0gZuTM9YMhQJPIbXqwidLRc/c2zuHt4RsrymmNv7A==",
       "cpu": [
         "x64"
       ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "darwin"
@@ -427,12 +901,17 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
-      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.0.tgz",
+      "integrity": "sha512-A8UpHoUDW4DwnXoV6+q3C1s7QLRAHtPDEjWuNZjwHMyoCNZnm0GeNN8ls9f/bsEYTRQRW96C/n34XJQHJ2fT7A==",
       "cpu": [
         "arm"
       ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "linux"
@@ -442,12 +921,17 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
-      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.0.tgz",
+      "integrity": "sha512-C0SqjoFKnszqa44EQ7xoaT48nnO0lOyXEULfXMWi8krrjOPGYkeK30Okzla6ATbBYsyZ0ySinK0FVkpv3DwzfQ==",
       "cpu": [
         "arm64"
       ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "linux"
@@ -457,12 +941,17 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-ppc64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
-      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.0.tgz",
+      "integrity": "sha512-WOpkVxAjFd369iaIzEgNRreFD+gWdUMIGD5zplhNKNeqS6mm5dac3q2AFyCBmzYoAdouzZvRBgxy4z8QHZb4/A==",
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "linux"
@@ -472,12 +961,17 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-riscv64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
-      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.0.tgz",
+      "integrity": "sha512-DRWw0mOHusrCCuw2rqP87oLg6PGlkomVDFqw2hIwsSfwWpu4k3XLcBPaKKl6ct/GtL/cwNkgwjV/tc0Mqht3VA==",
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "linux"
@@ -487,12 +981,17 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
-      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.0.tgz",
+      "integrity": "sha512-9APy+nFWhHS+kzLgWZfLcyrUd7YqnAQVa4BPOo4xkoHpdoktOAPG4cEr9+Jpl0TtqfVmcMJimNL5qNTyyOHZNA==",
       "cpu": [
         "s390x"
       ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "linux"
@@ -502,12 +1001,17 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
-      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.0.tgz",
+      "integrity": "sha512-y9RNUYDe2A1UAdhLyfeOodGRszQdaEoe4nfOpp/sNVPl2CWIcUyFaDoCh4vPLPxu19803j2naLqZup2WxDXCLA==",
       "cpu": [
         "x64"
       ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "linux"
@@ -517,12 +1021,17 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
-      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.0.tgz",
+      "integrity": "sha512-cC1wkC0Mlucd0KSiGrLkJnB/ZqPvZCntc/Lk7ZnYO5ZSbF2euNek4Xvxafojq+wN1q/W0eprdpUIjUr/EV2PBg==",
       "cpu": [
         "arm64"
       ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "linux"
@@ -532,12 +1041,17 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
-      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.0.tgz",
+      "integrity": "sha512-LiYMhUZicB1QG//+RvmYZpXJO8fYRENfp+MZUCnG9aw+AKvGAy9gPaCnuwsPcBFs8EV66M0NNxj9VHcNklE8zw==",
       "cpu": [
         "x64"
       ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "linux"
@@ -547,240 +1061,305 @@
       }
     },
     "node_modules/@img/sharp-linux-arm": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
-      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "version": "0.35.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.1.tgz",
+      "integrity": "sha512-jygmR02PpCYypt7xB7nst1vqjZp/BpRA/Kf9nK7qRponJ/KrLPaZWEG4G15z1d2FZ6XqI+T0350ha3RSnKx24A==",
       "cpu": [
         "arm"
       ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.2.4"
+        "@img/sharp-libvips-linux-arm": "1.3.0"
       }
     },
     "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
-      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "version": "0.35.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.1.tgz",
+      "integrity": "sha512-ErCRyGU7LeoaFBZ0xW8hhLlXzhAg80sc4vxePB86qvtEvW1jEhhmbiNBP4oEzZfPMnu6HwHXfzD2W2kBU+RnCw==",
       "cpu": [
         "arm64"
       ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.2.4"
+        "@img/sharp-libvips-linux-arm64": "1.3.0"
       }
     },
     "node_modules/@img/sharp-linux-ppc64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
-      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "version": "0.35.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.1.tgz",
+      "integrity": "sha512-LUWZ2+r2UoLCd8j0RLCwQ4gL6w47+Y7igxtVnPIDXOOEjV86LpBkAHq5VpJeg+GHbw0KN/JWlPJOdZjyZnFqFQ==",
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+        "@img/sharp-libvips-linux-ppc64": "1.3.0"
       }
     },
     "node_modules/@img/sharp-linux-riscv64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
-      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "version": "0.35.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.1.tgz",
+      "integrity": "sha512-i7x6J3mwF4JgT0sM4V4WlAWdJ0bucPtA9rzO1bTji1n5qgBq/W5nn87RvOQPleuuxahNoLdTngByD8/vDDLArw==",
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+        "@img/sharp-libvips-linux-riscv64": "1.3.0"
       }
     },
     "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
-      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "version": "0.35.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.1.tgz",
+      "integrity": "sha512-0zSaTUjTF0kIWTSYxD4EG/nvCU4jez53+3RdURtoY3HvbXtIQ98W90JnrGz/oLRFuEnfIy9+7xeq883euc0ZWw==",
       "cpu": [
         "s390x"
       ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.2.4"
+        "@img/sharp-libvips-linux-s390x": "1.3.0"
       }
     },
     "node_modules/@img/sharp-linux-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
-      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "version": "0.35.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.1.tgz",
+      "integrity": "sha512-NbJD4mWdeyrNQKluO/tR/wBDOelcowSVGNBWxI0e3ZtlXc6F/UOVKDj1MLD4zl3oHTuvKW3s+MA9N54YTldAYw==",
       "cpu": [
         "x64"
       ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.2.4"
+        "@img/sharp-libvips-linux-x64": "1.3.0"
       }
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
-      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "version": "0.35.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.1.tgz",
+      "integrity": "sha512-VoW2sQCWI+0YIKQEmWJ8vzaQjTg9wIyfkFpvEfAS2h43X6iHu7GTk1hhOgB4IpSzCHe8UwQZIcx7b81VTaOrJA==",
       "cpu": [
         "arm64"
       ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.0"
       }
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
-      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "version": "0.35.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.1.tgz",
+      "integrity": "sha512-LjBoSd/c5JU0/K5MwzDMlgsSRP2bPn98JQGFFQAOLQ0bU/1z4ekxUdSKY9BmlwSh/cA+OrvpgsWqfZyYfVHBRw==",
       "cpu": [
         "x64"
       ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.0"
       }
     },
     "node_modules/@img/sharp-wasm32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
-      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "version": "0.35.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.1.tgz",
+      "integrity": "sha512-PCQUoQdZyE8tp3HpbevuihfUmgSP4qWI0FGEPWoeXqaS+cUrFfemabHQiebUmUmlUhCuNnQMxGrQ+CPqK4hnxg==",
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.11.0"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.1.tgz",
+      "integrity": "sha512-xU2ml2bU2OPxYVvW2A6ae4M1g5QKyhKG06P4FAt+YEaFQQO0919Qx+XxIZEUuWTMoDViLpMws2/dQwoe/VcA6A==",
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
+      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@emnapi/runtime": "^1.7.0"
+        "@img/sharp-wasm32": "0.35.1"
       },
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
-      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "version": "0.35.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.1.tgz",
+      "integrity": "sha512-IkmHwuFhYpd3bTsN5SAahjwhiAcyXPooBt8vEUgxY3T0IP70sSJ0nU1xiPzZY8AH/OB1XpV3j8aZSVSOSfTbdA==",
       "cpu": [
         "arm64"
       ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
-      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "version": "0.35.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.1.tgz",
+      "integrity": "sha512-wQahqCi9MD8Yxzg4gVM4fNrZxh+r6vD55PyIg+WJPaM5ZRUyF35iQpwJCuma3r6viU9/8Pxlc+XHV+woVa6nCQ==",
       "cpu": [
         "ia32"
       ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": "^20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
-      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "version": "0.35.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.1.tgz",
+      "integrity": "sha512-WzBtkYtZHATLPe8XRharxZXxQ9cdLrQWHiwxt+BJ5rBsisQrKeeV86ErxPSVhcG6xCEuNhs0SqLpWr7XDa2k6w==",
       "cpu": [
         "x64"
       ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
@@ -4149,70 +4728,94 @@
       }
     },
     "node_modules/@supabase/auth-js": {
-      "version": "2.67.3",
-      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.67.3.tgz",
-      "integrity": "sha512-NJDaW8yXs49xMvWVOkSIr8j46jf+tYHV0wHhrwOaLLMZSFO4g6kKAf+MfzQ2RaD06OCUkUHIzctLAxjTgEVpzw==",
+      "version": "2.108.1",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.108.1.tgz",
+      "integrity": "sha512-Lle5rKU8f9LF3K5dDd8Or8mkkG+ptzRZZWKPVMm9B9UuovH65Ss2+iFnQqRsCqaGouvJEcTWyl0cj2riNrrDLQ==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@supabase/node-fetch": "^2.6.14"
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@supabase/functions-js": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.4.4.tgz",
-      "integrity": "sha512-WL2p6r4AXNGwop7iwvul2BvOtuJ1YQy8EbOd0dhG1oN1q8el/BIRSFCFnWAMM/vJJlHWLi4ad22sKbKr9mvjoA==",
+      "version": "2.108.1",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.108.1.tgz",
+      "integrity": "sha512-fxBRW/A4IG7ADQztVt0NaEy5ysiO1WJ2pbldsnBchrkHuyepX0Krek9qA9T4gUQBVVTCE9Ea4pdsM5hfn3nc4A==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@supabase/node-fetch": "^2.6.14"
-      }
-    },
-    "node_modules/@supabase/node-fetch": {
-      "version": "2.6.15",
-      "resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.15.tgz",
-      "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
+        "tslib": "2.8.1"
       },
       "engines": {
-        "node": "4.x || >=6.0.0"
+        "node": ">=20.0.0"
       }
     },
+    "node_modules/@supabase/phoenix": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.2.tgz",
+      "integrity": "sha512-YSAGnmDAfuleFCVt3CeurQZAhxRfXWeZIIkwp7NhYzQ1UwW6ePSnzsFAiUm/mbCkfoCf70QQHKW/K6RKh52a4A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@supabase/postgrest-js": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.18.1.tgz",
-      "integrity": "sha512-dWDnoC0MoDHKhaEOrsEKTadWQcBNknZVQcSgNE/Q2wXh05mhCL1ut/jthRUrSbYcqIw/CEjhaeIPp7dLarT0bg==",
+      "version": "2.108.1",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.108.1.tgz",
+      "integrity": "sha512-9lj2MCPPMgSTaJ5y+amnhb3TWPtMFVlbDn2hmX/VV91xQU4j0AauwfMaBErHBJ+zzsSwjc0jLU+zLIZFLQzfig==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@supabase/node-fetch": "^2.6.14"
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@supabase/realtime-js": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.11.2.tgz",
-      "integrity": "sha512-u/XeuL2Y0QEhXSoIPZZwR6wMXgB+RQbJzG9VErA3VghVt7uRfSVsjeqd7m5GhX3JR6dM/WRmLbVR8URpDWG4+w==",
+      "version": "2.108.1",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.108.1.tgz",
+      "integrity": "sha512-mHGGqOjwd1XTydcoffUqEMsbFQHUi6A3uhQ0EXr3iqzpLqItxKA9nbN6gIQxrZ7JRRnuUe/iOFPUkYV9Tdc5lg==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@supabase/node-fetch": "^2.6.14",
-        "@types/phoenix": "^1.5.4",
-        "@types/ws": "^8.5.10",
-        "ws": "^8.18.0"
+        "@supabase/phoenix": "^0.4.2",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@supabase/storage-js": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.7.1.tgz",
-      "integrity": "sha512-asYHcyDR1fKqrMpytAS1zjyEfvxuOIp1CIXX7ji4lHHcJKqyk+sLl/Vxgm4sN6u8zvuUtae9e4kDxQP2qrwWBA==",
+      "version": "2.108.1",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.108.1.tgz",
+      "integrity": "sha512-Er0SGGt85iT6ye+SSh98Az6L2CesoZJuyzEZYH2oBOAnIxa9Nn4CtwUC3veGxYggoT56X+3tVuuQeDBP8kR8sg==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@supabase/node-fetch": "^2.6.14"
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@supabase/supabase-js": {
-      "version": "2.48.1",
-      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.48.1.tgz",
-      "integrity": "sha512-VMD+CYk/KxfwGbI4fqwSUVA7CLr1izXpqfFerhnYPSi6LEKD8GoR4kuO5Cc8a+N43LnfSQwLJu4kVm2e4etEmA==",
+      "version": "2.108.1",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.108.1.tgz",
+      "integrity": "sha512-V/1hRKLSCJ0zEL+9QFRBUtivvePfOsaAYQmC0HhFNSHC2F3xFs4jSF3YhkLmzex6E4V4FGvmBDOP72D/53NnZA==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@supabase/auth-js": "2.67.3",
-        "@supabase/functions-js": "2.4.4",
-        "@supabase/node-fetch": "2.6.15",
-        "@supabase/postgrest-js": "1.18.1",
-        "@supabase/realtime-js": "2.11.2",
-        "@supabase/storage-js": "2.7.1"
+        "@supabase/auth-js": "2.108.1",
+        "@supabase/functions-js": "2.108.1",
+        "@supabase/postgrest-js": "2.108.1",
+        "@supabase/realtime-js": "2.108.1",
+        "@supabase/storage-js": "2.108.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@swc/helpers": {
@@ -4332,11 +4935,6 @@
         "undici-types": "~6.19.2"
       }
     },
-    "node_modules/@types/phoenix": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.6.tgz",
-      "integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A=="
-    },
     "node_modules/@types/react": {
       "version": "19.0.8",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.8.tgz",
@@ -4364,14 +4962,6 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
       "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ=="
-    },
-    "node_modules/@types/ws": {
-      "version": "8.5.14",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.14.tgz",
-      "integrity": "sha512-bd/YFLW+URhBzMXurx7lWByOu+xzU9+kb3RboOteXYDfW+tr+JZa99OyNmPINEGB/ahzKrEuc8rcv4gnpJmxTw==",
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.54.0",
@@ -5582,7 +6172,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "optional": true,
+      "devOptional": true,
       "engines": {
         "node": ">=8"
       }
@@ -5866,6 +6456,48 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/escalade": {
@@ -6846,6 +7478,16 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/idb": {
       "version": "8.0.3",
       "resolved": "https://registry.npmjs.org/idb/-/idb-8.0.3.tgz",
@@ -7733,6 +8375,510 @@
         "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
+    "node_modules/next/node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/next/node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -7758,6 +8904,51 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/next/node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
       }
     },
     "node_modules/node-releases": {
@@ -8739,10 +9930,11 @@
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="
     },
     "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
       "devOptional": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -8814,47 +10006,48 @@
       }
     },
     "node_modules/sharp": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
-      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
-      "hasInstallScript": true,
-      "optional": true,
+      "version": "0.35.1",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.1.tgz",
+      "integrity": "sha512-lW979AMi+ESidzMv/Lnv+F9bknzLyxLqFI05Sm433vOeRcltgxQmXpnfOOFIAlKtwXU/ksupm2srQoFCkR214g==",
+      "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@img/colour": "^1.0.0",
+        "@img/colour": "^1.1.0",
         "detect-libc": "^2.1.2",
-        "semver": "^7.7.3"
+        "semver": "^7.8.4"
       },
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.34.5",
-        "@img/sharp-darwin-x64": "0.34.5",
-        "@img/sharp-libvips-darwin-arm64": "1.2.4",
-        "@img/sharp-libvips-darwin-x64": "1.2.4",
-        "@img/sharp-libvips-linux-arm": "1.2.4",
-        "@img/sharp-libvips-linux-arm64": "1.2.4",
-        "@img/sharp-libvips-linux-ppc64": "1.2.4",
-        "@img/sharp-libvips-linux-riscv64": "1.2.4",
-        "@img/sharp-libvips-linux-s390x": "1.2.4",
-        "@img/sharp-libvips-linux-x64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
-        "@img/sharp-linux-arm": "0.34.5",
-        "@img/sharp-linux-arm64": "0.34.5",
-        "@img/sharp-linux-ppc64": "0.34.5",
-        "@img/sharp-linux-riscv64": "0.34.5",
-        "@img/sharp-linux-s390x": "0.34.5",
-        "@img/sharp-linux-x64": "0.34.5",
-        "@img/sharp-linuxmusl-arm64": "0.34.5",
-        "@img/sharp-linuxmusl-x64": "0.34.5",
-        "@img/sharp-wasm32": "0.34.5",
-        "@img/sharp-win32-arm64": "0.34.5",
-        "@img/sharp-win32-ia32": "0.34.5",
-        "@img/sharp-win32-x64": "0.34.5"
+        "@img/sharp-darwin-arm64": "0.35.1",
+        "@img/sharp-darwin-x64": "0.35.1",
+        "@img/sharp-freebsd-wasm32": "0.35.1",
+        "@img/sharp-libvips-darwin-arm64": "1.3.0",
+        "@img/sharp-libvips-darwin-x64": "1.3.0",
+        "@img/sharp-libvips-linux-arm": "1.3.0",
+        "@img/sharp-libvips-linux-arm64": "1.3.0",
+        "@img/sharp-libvips-linux-ppc64": "1.3.0",
+        "@img/sharp-libvips-linux-riscv64": "1.3.0",
+        "@img/sharp-libvips-linux-s390x": "1.3.0",
+        "@img/sharp-libvips-linux-x64": "1.3.0",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.0",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.0",
+        "@img/sharp-linux-arm": "0.35.1",
+        "@img/sharp-linux-arm64": "0.35.1",
+        "@img/sharp-linux-ppc64": "0.35.1",
+        "@img/sharp-linux-riscv64": "0.35.1",
+        "@img/sharp-linux-s390x": "0.35.1",
+        "@img/sharp-linux-x64": "0.35.1",
+        "@img/sharp-linuxmusl-arm64": "0.35.1",
+        "@img/sharp-linuxmusl-x64": "0.35.1",
+        "@img/sharp-webcontainers-wasm32": "0.35.1",
+        "@img/sharp-win32-arm64": "0.35.1",
+        "@img/sharp-win32-ia32": "0.35.1",
+        "@img/sharp-win32-x64": "0.35.1"
       }
     },
     "node_modules/shebang-command": {
@@ -9459,11 +10652,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-    },
     "node_modules/ts-api-utils": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
@@ -9497,6 +10685,25 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+    },
+    "node_modules/tsx": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -9776,20 +10983,6 @@
       "integrity": "sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==",
       "license": "Apache-2.0"
     },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
-    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -9977,26 +11170,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/yaml": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@radix-ui/react-toggle-group": "^1.1.1",
     "@radix-ui/react-tooltip": "^1.1.6",
     "@serwist/next": "^9.5.4",
-    "@supabase/supabase-js": "^2.48.1",
+    "@supabase/supabase-js": "^2.108.1",
     "@types/html2canvas": "^1.0.0",
     "@types/navermaps": "^3.7.8",
     "@types/uuid": "^10.0.0",
@@ -84,7 +84,9 @@
     "eslint": "^9",
     "eslint-config-next": "^15.5.12",
     "postcss": "^8",
+    "sharp": "^0.35.1",
     "tailwindcss": "^3.4.1",
+    "tsx": "^4.22.4",
     "typescript": "^5"
   }
 }

--- a/scripts/backfill-logo-thumbs.ts
+++ b/scripts/backfill-logo-thumbs.ts
@@ -1,0 +1,264 @@
+/**
+ * One-off backfill script: generate 256px WebP thumbnails for existing crew and store logos.
+ *
+ * Usage:
+ *   SUPABASE_URL=... SUPABASE_SERVICE_ROLE_KEY=... pnpm tsx scripts/backfill-logo-thumbs.ts
+ *   # (or: npx tsx scripts/backfill-logo-thumbs.ts)
+ *
+ * Required dev dependencies (install before running):
+ *   npm install --save-dev sharp tsx @supabase/supabase-js
+ *
+ * What it does:
+ *   1. Reads SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY from process.env.
+ *   2. Selects crews where logo_image_url IS NOT NULL AND logo_thumb_url IS NULL.
+ *      Selects stores where logo_url IS NOT NULL AND logo_thumb_url IS NULL.
+ *   3. For each row:
+ *      - Downloads the original image via fetch.
+ *      - Resizes to 256px (max width/height, preserving aspect ratio) using sharp.
+ *      - Converts to WebP.
+ *      - Uploads to the same Supabase storage bucket with `_thumb.webp` suffix.
+ *      - Updates the row's logo_thumb_url column with the new public URL.
+ *   4. Logs progress per row and a final summary.
+ *
+ * Notes:
+ *   - sharp is used (NOT browser-image-compression) because this runs in Node.
+ *   - Crew logos live in the 'crewLogos' bucket; store logos live in the 'storePhotos' bucket.
+ *   - This script uses the service-role key, which bypasses RLS. Do not commit the key.
+ */
+
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import sharp from 'sharp';
+
+const SUPABASE_URL = process.env.SUPABASE_URL;
+const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) {
+  console.error(
+    '[backfill] Missing required env vars. Please set SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY.',
+  );
+  process.exit(1);
+}
+
+const CREW_BUCKET = 'crewLogos';
+const STORE_BUCKET = 'storePhotos';
+const THUMB_MAX_DIMENSION = 256;
+
+const supabase: SupabaseClient = createClient(
+  SUPABASE_URL,
+  SUPABASE_SERVICE_ROLE_KEY,
+  {
+    auth: { persistSession: false, autoRefreshToken: false },
+  },
+);
+
+interface BackfillResult {
+  processed: number;
+  succeeded: number;
+  failed: number;
+}
+
+/**
+ * Derive the storage object key for the thumbnail from the original public URL.
+ * Supabase public URLs look like:
+ *   {SUPABASE_URL}/storage/v1/object/public/{bucket}/{objectKey}?v=...
+ * We strip the prefix and query string, then replace the extension with `_thumb.webp`.
+ */
+function deriveThumbObjectKey(
+  originalUrl: string,
+  bucket: string,
+): string | null {
+  try {
+    const url = new URL(originalUrl);
+    const marker = `/storage/v1/object/public/${bucket}/`;
+    const idx = url.pathname.indexOf(marker);
+    if (idx === -1) return null;
+    const objectKey = url.pathname.substring(idx + marker.length);
+    // Drop existing extension and append _thumb.webp.
+    const dot = objectKey.lastIndexOf('.');
+    const base = dot === -1 ? objectKey : objectKey.substring(0, dot);
+    return `${base}_thumb.webp`;
+  } catch {
+    return null;
+  }
+}
+
+async function generateThumb(sourceUrl: string): Promise<Buffer> {
+  const res = await fetch(sourceUrl);
+  if (!res.ok) {
+    throw new Error(
+      `Failed to fetch ${sourceUrl}: ${res.status} ${res.statusText}`,
+    );
+  }
+  const arrayBuffer = await res.arrayBuffer();
+  const input = Buffer.from(arrayBuffer);
+  return await sharp(input)
+    .resize(THUMB_MAX_DIMENSION, THUMB_MAX_DIMENSION, {
+      fit: 'inside',
+      withoutEnlargement: true,
+    })
+    .webp({ quality: 80 })
+    .toBuffer();
+}
+
+async function uploadThumb(
+  bucket: string,
+  objectKey: string,
+  data: Buffer,
+): Promise<string> {
+  const { error: uploadError } = await supabase.storage
+    .from(bucket)
+    .upload(objectKey, data, {
+      contentType: 'image/webp',
+      upsert: true,
+      cacheControl: '3600',
+    });
+  if (uploadError) {
+    throw new Error(`Upload failed for ${bucket}/${objectKey}: ${uploadError.message}`);
+  }
+  const { data: publicUrlData } = supabase.storage
+    .from(bucket)
+    .getPublicUrl(objectKey);
+  const baseUrl = publicUrlData.publicUrl;
+  // Cache-bust to match patterns used elsewhere in the codebase.
+  return `${baseUrl}?v=${Date.now()}`;
+}
+
+async function backfillCrews(): Promise<BackfillResult> {
+  const result: BackfillResult = { processed: 0, succeeded: 0, failed: 0 };
+
+  const { data: rows, error } = await supabase
+    .from('crews')
+    .select('id, name, logo_image_url')
+    .not('logo_image_url', 'is', null)
+    .is('logo_thumb_url', null);
+
+  if (error) {
+    console.error('[backfill][crews] select failed:', error.message);
+    return result;
+  }
+
+  console.log(`[backfill][crews] found ${rows?.length ?? 0} rows needing thumbnails`);
+
+  for (const row of rows ?? []) {
+    result.processed += 1;
+    const id = (row as { id: string }).id;
+    const name = (row as { name?: string }).name ?? '(no name)';
+    const originalUrl = (row as { logo_image_url: string }).logo_image_url;
+    try {
+      const thumbKey = deriveThumbObjectKey(originalUrl, CREW_BUCKET);
+      if (!thumbKey) {
+        throw new Error(
+          `Could not derive object key from URL: ${originalUrl}`,
+        );
+      }
+      const thumbBuffer = await generateThumb(originalUrl);
+      const thumbUrl = await uploadThumb(CREW_BUCKET, thumbKey, thumbBuffer);
+
+      const { error: updateError } = await supabase
+        .from('crews')
+        .update({ logo_thumb_url: thumbUrl })
+        .eq('id', id);
+
+      if (updateError) {
+        throw new Error(`DB update failed: ${updateError.message}`);
+      }
+
+      result.succeeded += 1;
+      console.log(
+        `[backfill][crews] (${result.processed}/${rows?.length ?? 0}) OK id=${id} name=${name}`,
+      );
+    } catch (err) {
+      result.failed += 1;
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(
+        `[backfill][crews] (${result.processed}/${rows?.length ?? 0}) FAIL id=${id} name=${name}: ${message}`,
+      );
+    }
+  }
+
+  return result;
+}
+
+async function backfillStores(): Promise<BackfillResult> {
+  const result: BackfillResult = { processed: 0, succeeded: 0, failed: 0 };
+
+  const { data: rows, error } = await supabase
+    .from('stores')
+    .select('id, name, logo_url')
+    .not('logo_url', 'is', null)
+    .is('logo_thumb_url', null);
+
+  if (error) {
+    console.error('[backfill][stores] select failed:', error.message);
+    return result;
+  }
+
+  console.log(`[backfill][stores] found ${rows?.length ?? 0} rows needing thumbnails`);
+
+  for (const row of rows ?? []) {
+    result.processed += 1;
+    const id = (row as { id: string }).id;
+    const name = (row as { name?: string }).name ?? '(no name)';
+    const originalUrl = (row as { logo_url: string }).logo_url;
+    try {
+      const thumbKey = deriveThumbObjectKey(originalUrl, STORE_BUCKET);
+      if (!thumbKey) {
+        throw new Error(
+          `Could not derive object key from URL: ${originalUrl}`,
+        );
+      }
+      const thumbBuffer = await generateThumb(originalUrl);
+      const thumbUrl = await uploadThumb(STORE_BUCKET, thumbKey, thumbBuffer);
+
+      const { error: updateError } = await supabase
+        .from('stores')
+        .update({ logo_thumb_url: thumbUrl })
+        .eq('id', id);
+
+      if (updateError) {
+        throw new Error(`DB update failed: ${updateError.message}`);
+      }
+
+      result.succeeded += 1;
+      console.log(
+        `[backfill][stores] (${result.processed}/${rows?.length ?? 0}) OK id=${id} name=${name}`,
+      );
+    } catch (err) {
+      result.failed += 1;
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(
+        `[backfill][stores] (${result.processed}/${rows?.length ?? 0}) FAIL id=${id} name=${name}: ${message}`,
+      );
+    }
+  }
+
+  return result;
+}
+
+async function main() {
+  console.log('[backfill] Starting logo thumbnail backfill...');
+  const startedAt = Date.now();
+
+  const crewResult = await backfillCrews();
+  const storeResult = await backfillStores();
+
+  const elapsedSec = ((Date.now() - startedAt) / 1000).toFixed(1);
+  console.log('');
+  console.log('[backfill] ===== Summary =====');
+  console.log(
+    `[backfill] Crews:  ${crewResult.succeeded} backfilled, ${crewResult.failed} failed (of ${crewResult.processed} processed)`,
+  );
+  console.log(
+    `[backfill] Stores: ${storeResult.succeeded} backfilled, ${storeResult.failed} failed (of ${storeResult.processed} processed)`,
+  );
+  console.log(`[backfill] Total elapsed: ${elapsedSec}s`);
+
+  if (crewResult.failed > 0 || storeResult.failed > 0) {
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error('[backfill] Fatal error:', err);
+  process.exit(1);
+});

--- a/src/app/_components/MapPageClient.tsx
+++ b/src/app/_components/MapPageClient.tsx
@@ -396,7 +396,7 @@ export default function MapPageClient({
         <Sheet open={isStoreDetailOpen} onOpenChange={closeStoreDetail}>
           <SheetContent
             side='bottom'
-            className='h-[85vh] overflow-y-auto p-0 sm:max-w-full'
+            className='h-[85vh] p-0 rounded-t-[10px] overflow-hidden z-[10000] bg-background text-cart-ink md:w-[430px] md:left-[calc(50vw-215px)] md:right-auto md:rounded-[4px] md:border md:border-cart-rule md:shadow-2xl'
           >
             <SheetTitle className='sr-only'>
               {selectedStore ? selectedStore.name : "매장 상세"}

--- a/src/app/admin/crew/edit/[id]/page.tsx
+++ b/src/app/admin/crew/edit/[id]/page.tsx
@@ -67,6 +67,7 @@ interface CrewUpdateData {
     max_age: number;
   };
   logo_image_url?: string;
+  logo_thumb_url?: string;
   use_instagram_dm?: boolean;
   open_chat_link?: string;
   crew_photos?: {
@@ -355,10 +356,14 @@ export default function EditCrewPage() {
     try {
       setIsSaving(true);
       let updatedImageUrl = crew?.logo_image;
+      let updatedThumbUrl = crew?.logo_thumb_url ?? undefined;
       if (logoImage) {
         try {
-          const url = await crewService.uploadCrewLogo(logoImage, crewId);
-          if (url) updatedImageUrl = url;
+          const uploaded = await crewService.uploadCrewLogo(logoImage, crewId);
+          if (uploaded) {
+            updatedImageUrl = uploaded.logo_image;
+            updatedThumbUrl = uploaded.logo_thumb_url;
+          }
         } catch (err) {
           console.error("로고 업로드 실패:", err);
           toast.error("로고 이미지 업로드에 실패했습니다.");
@@ -395,6 +400,7 @@ export default function EditCrewPage() {
         founded_date: foundedDate || undefined,
         age_range: { min_age: minAge, max_age: maxAge },
         logo_image_url: updatedImageUrl,
+        logo_thumb_url: updatedThumbUrl,
       };
 
       if (useInstagramDm) updateData.use_instagram_dm = true;

--- a/src/app/menu/page.tsx
+++ b/src/app/menu/page.tsx
@@ -53,10 +53,10 @@ export default function MenuPage() {
 
   return (
     <div
-      className='flex flex-col bg-background'
+      className='flex flex-col min-h-screen bg-background'
       style={{
-        height: CSS_VARIABLES.CONTENT_HEIGHT_MOBILE,
         paddingTop: CSS_VARIABLES.HEADER_PADDING,
+        paddingBottom: CSS_VARIABLES.MOBILE_NAV_PADDING,
       }}
     >
       <CartographicHeader

--- a/src/app/store/page.tsx
+++ b/src/app/store/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { getVisibleStores } from "@/lib/server/stores";
 import { StoreList } from "@/components/store/StoreList";
 import { CartographicHeader } from "@/components/design/cartographic";
+import { CSS_VARIABLES } from "@/lib/constants";
 
 export const metadata: Metadata = {
   title: "러닝 인증 매장 — 런하우스",
@@ -13,7 +14,13 @@ export const metadata: Metadata = {
 export default async function StoreIndexPage() {
   const stores = await getVisibleStores();
   return (
-    <main className="mx-auto max-w-5xl px-4 py-6">
+    <main
+      className="mx-auto max-w-5xl px-4 pb-6"
+      style={{
+        paddingTop: `calc(${CSS_VARIABLES.HEADER_PADDING} + 1rem)`,
+        paddingBottom: CSS_VARIABLES.MOBILE_NAV_PADDING,
+      }}
+    >
       {/* 카토그래픽 헤더 — 크루 리스트와 동일한 kicker + title 처리 */}
       <CartographicHeader
         kicker={`STORES · ${stores.length.toString().padStart(3, "0")}`}

--- a/src/components/crew/CrewList.tsx
+++ b/src/components/crew/CrewList.tsx
@@ -206,7 +206,7 @@ export const CrewList = ({ crews, onSelect }: CrewListProps) => {
               {crew.logo_image ? (
                 <div className='relative flex items-center justify-center flex-shrink-0 w-10 h-10 mr-3 overflow-hidden border border-cart-rule rounded-full'>
                   <Image
-                    src={crew.logo_image}
+                    src={crew.logo_thumb_url ?? crew.logo_image}
                     alt={crew.name}
                     width={40}
                     height={40}
@@ -215,6 +215,7 @@ export const CrewList = ({ crews, onSelect }: CrewListProps) => {
                     loading={index < 10 ? "eager" : "lazy"}
                     quality={40}
                     sizes='40px'
+                    unoptimized
                   />
                 </div>
               ) : (

--- a/src/components/map/VisibleCrewList.tsx
+++ b/src/components/map/VisibleCrewList.tsx
@@ -73,11 +73,12 @@ export function VisibleCrewList({
                     {crew.logo_image ? (
                       <>
                         <Image
-                          src={crew.logo_image}
+                          src={crew.logo_thumb_url ?? crew.logo_image}
                           alt={`${crew.name} 로고`}
                           width={48}
                           height={48}
                           quality={30}
+                          unoptimized
                           className='flex-shrink-0 object-cover transition-opacity rounded-full group-hover:opacity-90'
                           loading='lazy'
                           priority={false}

--- a/src/components/pwa/InstallPrompt.tsx
+++ b/src/components/pwa/InstallPrompt.tsx
@@ -49,7 +49,9 @@ export function InstallPrompt() {
   if (!showPrompt) return null;
 
   return (
-    <div className="fixed bottom-[calc(4.5rem+env(safe-area-inset-bottom,0px)+12px)] left-4 right-4 z-[9998] animate-fade-in-up">
+    <div
+      className="fixed bottom-[calc(4.5rem+env(safe-area-inset-bottom,0px)+12px)] left-4 right-4 md:left-[calc(50vw-215px+16px)] md:right-auto md:w-[398px] z-[9998] animate-fade-in-up"
+    >
       <div className="flex items-center gap-3 p-4 rounded-[4px] bg-[hsl(220,14%,9%)] border border-white/[0.08] shadow-2xl">
         <div className="flex-shrink-0 w-10 h-10 rounded-[4px] bg-[hsl(72,100%,50%)] flex items-center justify-center">
           <Download className="w-5 h-5 text-cart-ink" />

--- a/src/components/regions/RegionCrewRow.tsx
+++ b/src/components/regions/RegionCrewRow.tsx
@@ -29,12 +29,13 @@ export function RegionCrewRow({
       {crew.logo_image ? (
         <div className="relative flex-shrink-0 w-9 h-9 rounded-[4px] overflow-hidden border border-cart-rule bg-cart-paper">
           <Image
-            src={crew.logo_image}
+            src={crew.logo_thumb_url ?? crew.logo_image}
             alt={crew.name}
             width={36}
             height={36}
             className="object-cover w-full h-full"
             sizes="36px"
+            unoptimized
           />
         </div>
       ) : (

--- a/src/components/store/StoreCard.tsx
+++ b/src/components/store/StoreCard.tsx
@@ -27,12 +27,14 @@ export function StoreRow({
       {store.logo_url ? (
         <div className="relative flex-shrink-0 w-9 h-9 rounded-[4px] overflow-hidden border border-cart-rule bg-cart-paper">
           <Image
-            src={store.logo_url}
+            src={store.logo_thumb_url ?? store.logo_url}
             alt={store.name}
             width={36}
             height={36}
             className="object-cover w-full h-full"
             sizes="36px"
+            quality={40}
+            unoptimized
           />
         </div>
       ) : (

--- a/src/components/store/StoreDetailView.tsx
+++ b/src/components/store/StoreDetailView.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Image from "next/image";
 import type { Store } from "@/lib/types/store";
 import { STORE_CATEGORY_LABELS } from "@/lib/types/store";
@@ -14,6 +14,9 @@ import {
   Gift,
   MessageSquare,
   Tag,
+  X,
+  ChevronLeft,
+  ChevronRight,
 } from "lucide-react";
 import { StoreCategoryIcon } from "./StoreCategoryIcon";
 
@@ -21,6 +24,26 @@ type TabType = "info" | "photos";
 
 export function StoreDetailView({ store }: { store: Store }) {
   const [activeTab, setActiveTab] = useState<TabType>("info");
+  const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (lightboxIndex === null) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setLightboxIndex(null);
+      else if (e.key === "ArrowLeft")
+        setLightboxIndex((idx) => (idx === null ? null : (idx - 1 + allPhotos.length) % allPhotos.length));
+      else if (e.key === "ArrowRight")
+        setLightboxIndex((idx) => (idx === null ? null : (idx + 1) % allPhotos.length));
+    };
+    window.addEventListener("keydown", onKey);
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      window.removeEventListener("keydown", onKey);
+      document.body.style.overflow = prev;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [lightboxIndex]);
 
   const igHandle = store.instagram?.replace(/^@/, "");
 
@@ -300,13 +323,16 @@ export function StoreDetailView({ store }: { store: Store }) {
             {allPhotos.length > 0 ? (
               <div className="grid grid-cols-2 gap-2">
                 {allPhotos.map((url, i) => (
-                  <div
+                  <button
+                    type="button"
                     key={url}
-                    className={`relative overflow-hidden rounded-[4px] border border-cart-rule bg-cart-paper ${
+                    onClick={() => setLightboxIndex(i)}
+                    className={`relative overflow-hidden rounded-[4px] border border-cart-rule bg-cart-paper cursor-zoom-in active:scale-[0.98] transition-transform ${
                       i === 0 && allPhotos.length > 1
                         ? "col-span-2 aspect-video"
                         : "aspect-square"
                     }`}
+                    aria-label={`${store.name} 사진 ${i + 1} 크게 보기`}
                   >
                     <Image
                       src={url}
@@ -318,7 +344,7 @@ export function StoreDetailView({ store }: { store: Store }) {
                       priority={i === 0}
                       style={{ objectFit: "cover" }}
                     />
-                  </div>
+                  </button>
                 ))}
               </div>
             ) : (
@@ -333,6 +359,74 @@ export function StoreDetailView({ store }: { store: Store }) {
           </div>
         )}
       </div>
+
+      {lightboxIndex !== null && allPhotos[lightboxIndex] && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-label="사진 크게 보기"
+          className="fixed inset-0 z-[10001] flex items-center justify-center bg-black/95 animate-fade-in"
+          onClick={() => setLightboxIndex(null)}
+        >
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              setLightboxIndex(null);
+            }}
+            className="absolute top-4 right-4 w-10 h-10 rounded-[4px] bg-white/10 hover:bg-white/20 flex items-center justify-center text-white z-10"
+            aria-label="닫기"
+          >
+            <X className="w-5 h-5" />
+          </button>
+
+          {allPhotos.length > 1 && (
+            <>
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setLightboxIndex((lightboxIndex - 1 + allPhotos.length) % allPhotos.length);
+                }}
+                className="absolute left-4 top-1/2 -translate-y-1/2 w-11 h-11 rounded-[4px] bg-white/10 hover:bg-white/20 flex items-center justify-center text-white z-10"
+                aria-label="이전 사진"
+              >
+                <ChevronLeft className="w-6 h-6" />
+              </button>
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setLightboxIndex((lightboxIndex + 1) % allPhotos.length);
+                }}
+                className="absolute right-4 top-1/2 -translate-y-1/2 w-11 h-11 rounded-[4px] bg-white/10 hover:bg-white/20 flex items-center justify-center text-white z-10"
+                aria-label="다음 사진"
+              >
+                <ChevronRight className="w-6 h-6" />
+              </button>
+              <div className="absolute bottom-6 left-1/2 -translate-x-1/2 font-mono text-[11px] tracking-[0.2em] text-white/70 uppercase">
+                {lightboxIndex + 1} / {allPhotos.length}
+              </div>
+            </>
+          )}
+
+          <div
+            className="relative w-[92vw] h-[80vh] max-w-[1100px]"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <Image
+              src={allPhotos[lightboxIndex]}
+              alt={`${store.name} 사진 ${lightboxIndex + 1}`}
+              fill
+              sizes="100vw"
+              className="object-contain"
+              quality={90}
+              unoptimized
+              priority
+            />
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/store/StoreList.tsx
+++ b/src/components/store/StoreList.tsx
@@ -79,7 +79,7 @@ export function StoreList({ stores }: { stores: Store[] }) {
       >
         <SheetContent
           side="bottom"
-          className="h-[85vh] overflow-y-auto p-0 sm:max-w-full"
+          className="h-[85vh] p-0 rounded-t-[10px] overflow-hidden z-[10000] bg-background text-cart-ink md:w-[430px] md:left-[calc(50vw-215px)] md:right-auto md:rounded-[4px] md:border md:border-cart-rule md:shadow-2xl"
         >
           <SheetTitle className="sr-only">
             {selectedStore ? selectedStore.name : "매장 상세"}

--- a/src/lib/services/crew.service.ts
+++ b/src/lib/services/crew.service.ts
@@ -8,7 +8,7 @@ import type {
 import { Crew } from "@/lib/types/crew";
 import { logger } from "@/lib/utils/logger";
 import { ErrorCode } from "@/lib/types/error";
-import { compressImageFile } from "@/lib/utils/imageCompression";
+import { compressImageFile, generateThumbnail } from "@/lib/utils/imageCompression";
 import { convertToWebP } from "@/lib/utils/imageConversion";
 
 // Supabase 응답 타입 정의
@@ -18,6 +18,7 @@ interface DbCrew {
   description: string;
   instagram?: string;
   logo_image_url?: string;
+  logo_thumb_url?: string;
   founded_date: string;
   created_at: string;
   updated_at: string;
@@ -59,7 +60,7 @@ class CrewService {
   private async uploadImage(
     file: File,
     crewId: string
-  ): Promise<string | null> {
+  ): Promise<{ logo_image: string; logo_thumb_url: string } | null> {
     try {
       // console.log("=== 이미지 업로드 시작 ===");
       // console.log("파일 정보:", {
@@ -133,7 +134,39 @@ class CrewService {
       // console.log("생성된 공개 URL:", publicUrl.toString());
       console.log("=== 이미지 업로드 완료 ===");
 
-      return publicUrl.toString();
+      // 썸네일 생성 및 업로드 (실패해도 원본 업로드는 유지)
+      let thumbUrlString = publicUrl.toString();
+      try {
+        const thumbFile = await generateThumbnail(file, 256);
+        const baseName = fileName.replace(/\.[^/.]+$/, "");
+        const thumbFileName = `${baseName}_thumb.webp`;
+
+        const { error: thumbUploadError } = await supabase.storage
+          .from(this.BUCKET_NAME)
+          .upload(thumbFileName, thumbFile, {
+            cacheControl: "31536000",
+            contentType: "image/webp",
+            upsert: true,
+          });
+
+        if (thumbUploadError) {
+          console.error("썸네일 업로드 실패:", thumbUploadError);
+        } else {
+          const { data: thumbData } = supabase.storage
+            .from(this.BUCKET_NAME)
+            .getPublicUrl(thumbFileName);
+          const thumbUrl = new URL(thumbData.publicUrl);
+          thumbUrl.searchParams.set("v", timestamp.toString());
+          thumbUrlString = thumbUrl.toString();
+        }
+      } catch (thumbError) {
+        console.error("썸네일 생성/업로드 실패:", thumbError);
+      }
+
+      return {
+        logo_image: publicUrl.toString(),
+        logo_thumb_url: thumbUrlString,
+      };
     } catch (error) {
       console.error("=== 이미지 업로드 실패 ===");
       console.error("에러 상세 정보:", {
@@ -157,7 +190,10 @@ class CrewService {
   }
 
   // 크루 로고 업로드를 위한 공개 메서드 추가
-  async uploadCrewLogo(file: File, crewId: string): Promise<string | null> {
+  async uploadCrewLogo(
+    file: File,
+    crewId: string
+  ): Promise<{ logo_image: string; logo_thumb_url: string } | null> {
     try {
       // 이미지 유효성 검사
       await this.validateImage(file);
@@ -181,7 +217,7 @@ class CrewService {
         }
       }
 
-      // 이미지 업로드
+      // 이미지 업로드 (원본 + 썸네일)
       return await this.uploadImage(processedFile, crewId);
     } catch (error) {
       console.error("로고 업로드 실패:", error);
@@ -284,17 +320,19 @@ class CrewService {
 
       // 이미지 검증 및 압축, 업로드 수행
       let logo_image_url: string | undefined;
+      let logo_thumb_url: string | undefined;
       if (input.logo_image) {
         try {
           console.log("로고 이미지 처리 시작");
-          const uploadedUrl = await this.uploadCrewLogo(
+          const uploaded = await this.uploadCrewLogo(
             input.logo_image,
             crypto.randomUUID()
           );
-          if (!uploadedUrl) {
+          if (!uploaded) {
             throw logger.createError(ErrorCode.UPLOAD_FAILED);
           }
-          logo_image_url = uploadedUrl;
+          logo_image_url = uploaded.logo_image;
+          logo_thumb_url = uploaded.logo_thumb_url;
           console.log("로고 이미지 업로드 완료:", logo_image_url);
         } catch (error) {
           if (
@@ -320,6 +358,7 @@ class CrewService {
           description: input.description,
           instagram: input.instagram,
           logo_image_url,
+          logo_thumb_url,
           founded_date: input.founded_date,
         })
         .select("id")
@@ -509,6 +548,7 @@ class CrewService {
         description: input.description,
         instagram: input.instagram,
         logo_image_url,
+        logo_thumb_url,
         founded_date: input.founded_date,
         location: {
           main_address: input.location.main_address,
@@ -1101,6 +1141,7 @@ class CrewService {
         max_age: number;
       };
       logo_image_url?: string; // 로고 이미지 URL 추가
+      logo_thumb_url?: string; // 로고 썸네일 URL 추가
       use_instagram_dm?: boolean; // 인스타그램 DM 사용 여부 추가
       open_chat_link?: string; // 오픈채팅 링크 추가
       crew_photos?: {
@@ -1124,6 +1165,7 @@ class CrewService {
             instagram: updateData.instagram || null,
             founded_date: updateData.founded_date || undefined,
             logo_image_url: updateData.logo_image_url || undefined,
+            logo_thumb_url: updateData.logo_thumb_url || undefined,
           })
           .eq("id", crewId),
         supabase
@@ -1319,7 +1361,7 @@ class CrewService {
       // 크루 정보 조회 (로고 이미지 URL 확인을 위해)
       const { data: crew, error: getError } = await supabase
         .from("crews")
-        .select("logo_image_url")
+        .select("logo_image_url, logo_thumb_url")
         .eq("id", crewId)
         .single();
 
@@ -1338,10 +1380,23 @@ class CrewService {
           const pathParts = url.pathname.split("/");
           const fileName = pathParts[pathParts.length - 1].split("?")[0]; // 쿼리 파라미터 제거
 
+          // 썸네일 파일명도 함께 삭제 (있는 경우)
+          const filesToRemove: string[] = [fileName];
+          if (crew.logo_thumb_url) {
+            try {
+              const thumbUrl = new URL(crew.logo_thumb_url);
+              const thumbParts = thumbUrl.pathname.split("/");
+              const thumbFileName = thumbParts[thumbParts.length - 1].split("?")[0];
+              filesToRemove.push(thumbFileName);
+            } catch (thumbErr) {
+              console.error("썸네일 URL 파싱 실패:", thumbErr);
+            }
+          }
+
           // 스토리지에서 이미지 삭제
           const { error: deleteImageError } = await supabase.storage
             .from(this.BUCKET_NAME)
-            .remove([fileName]);
+            .remove(filesToRemove);
 
           if (deleteImageError) {
             // 이미지 삭제 실패는 로깅만 하고 크루 삭제는 계속 진행

--- a/src/lib/services/store.service.ts
+++ b/src/lib/services/store.service.ts
@@ -1,6 +1,7 @@
 // src/lib/services/store.service.ts
 import { supabase } from "@/lib/supabase/client";
 import imageCompression from "browser-image-compression";
+import { generateThumbnail } from "@/lib/utils/imageCompression";
 import type {
   Store,
   StoreAdmin,
@@ -49,6 +50,48 @@ class StoreService {
     return `${data.publicUrl}?v=${Date.now()}`;
   }
 
+  // 로고 전용 업로드: 원본 webp + 256px 썸네일을 같은 버킷에 업로드한다.
+  // 썸네일 생성/업로드 실패는 원본 업로드를 막지 않는다(thumb URL은 null).
+  private async uploadLogoWithThumb(
+    storeId: string,
+    file: File
+  ): Promise<{ url: string; thumbUrl: string | null }> {
+    this.validateImage(file);
+    const webp = await this.compressToWebp(file);
+    const ts = Date.now();
+    const name = `${storeId}_${ts}.webp`;
+    const { error } = await supabase.storage
+      .from(this.BUCKET)
+      .upload(name, webp, { upsert: true, contentType: "image/webp" });
+    if (error) throw error;
+    const { data } = supabase.storage.from(this.BUCKET).getPublicUrl(name);
+    const url = `${data.publicUrl}?v=${ts}`;
+
+    let thumbUrl: string | null = null;
+    try {
+      const thumb = await generateThumbnail(webp, 256);
+      const thumbName = `${storeId}_${ts}_thumb.webp`;
+      const { error: thumbErr } = await supabase.storage
+        .from(this.BUCKET)
+        .upload(thumbName, thumb, {
+          upsert: true,
+          contentType: "image/webp",
+        });
+      if (thumbErr) {
+        console.warn("store logo thumbnail upload failed:", thumbErr);
+      } else {
+        const { data: thumbData } = supabase.storage
+          .from(this.BUCKET)
+          .getPublicUrl(thumbName);
+        thumbUrl = `${thumbData.publicUrl}?v=${ts}`;
+      }
+    } catch (e) {
+      console.warn("store logo thumbnail generation failed:", e);
+    }
+
+    return { url, thumbUrl };
+  }
+
   private async removeByPublicUrl(url: string): Promise<void> {
     // 파일명만 추출해 remove
     const last = url.split("?")[0].split("/").pop();
@@ -90,8 +133,14 @@ class StoreService {
     const storePatch: Record<string, unknown> = { main_image_url: mainUrl };
 
     // 3-1. 로고(선택) 업로드 + URL 패치 (main_image와 동일 storePhotos 버킷 재사용)
+    // 로고는 원본과 함께 256px 썸네일도 함께 업로드한다(지도 마커 등 작은 표시용).
     if (input.logo) {
-      storePatch.logo_url = await this.uploadOne(storeId, input.logo);
+      const { url, thumbUrl } = await this.uploadLogoWithThumb(
+        storeId,
+        input.logo
+      );
+      storePatch.logo_url = url;
+      storePatch.logo_thumb_url = thumbUrl;
     }
 
     await supabase.from("stores").update(storePatch).eq("id", storeId);
@@ -342,26 +391,37 @@ class StoreService {
     }
 
     // 로고 교체/제거 (main_image와 동일 패턴, storePhotos 버킷 재사용)
+    // 로고는 원본 + 256px 썸네일 한 쌍으로 관리한다.
     if (input.logo) {
-      // 기존 로고 URL 가져와 삭제
+      // 기존 로고/썸네일 URL 가져와 삭제
       const { data: prev } = await supabase
         .from("stores")
-        .select("logo_url")
+        .select("logo_url, logo_thumb_url")
         .eq("id", id)
         .single();
-      const newUrl = await this.uploadOne(id, input.logo);
-      patch.logo_url = newUrl;
-      const prevUrl = (prev as { logo_url?: string } | null)?.logo_url;
-      if (prevUrl) await this.removeByPublicUrl(prevUrl);
+      const { url, thumbUrl } = await this.uploadLogoWithThumb(id, input.logo);
+      patch.logo_url = url;
+      patch.logo_thumb_url = thumbUrl;
+      const prevRow = prev as
+        | { logo_url?: string; logo_thumb_url?: string }
+        | null;
+      if (prevRow?.logo_url) await this.removeByPublicUrl(prevRow.logo_url);
+      if (prevRow?.logo_thumb_url)
+        await this.removeByPublicUrl(prevRow.logo_thumb_url);
     } else if (input.remove_logo) {
       const { data: prev } = await supabase
         .from("stores")
-        .select("logo_url")
+        .select("logo_url, logo_thumb_url")
         .eq("id", id)
         .single();
-      const prevUrl = (prev as { logo_url?: string } | null)?.logo_url;
-      if (prevUrl) await this.removeByPublicUrl(prevUrl);
+      const prevRow = prev as
+        | { logo_url?: string; logo_thumb_url?: string }
+        | null;
+      if (prevRow?.logo_url) await this.removeByPublicUrl(prevRow.logo_url);
+      if (prevRow?.logo_thumb_url)
+        await this.removeByPublicUrl(prevRow.logo_thumb_url);
       patch.logo_url = null;
+      patch.logo_thumb_url = null;
     }
 
     if (Object.keys(patch).length > 0) {

--- a/src/lib/types/crew.ts
+++ b/src/lib/types/crew.ts
@@ -4,6 +4,7 @@ export interface Crew {
   description: string;
   instagram?: string;
   logo_image?: string;
+  logo_thumb_url?: string | null;
   founded_date: string;
   created_at: string;
   activity_day?: string;

--- a/src/lib/types/crewInsert.ts
+++ b/src/lib/types/crewInsert.ts
@@ -4,6 +4,7 @@ export interface Crew {
   description: string;
   instagram?: string;
   logo_image_url?: string;
+  logo_thumb_url?: string | null;
   founded_date: string;
   created_at: string;
   updated_at: string;

--- a/src/lib/types/store.ts
+++ b/src/lib/types/store.ts
@@ -33,6 +33,7 @@ export interface Store {
   event_post_url?: string;
   main_image_url?: string;
   logo_url?: string; // 매장 로고 (선택). 없으면 지도 마커는 카테고리 색 글자 원으로 fallback.
+  logo_thumb_url?: string | null;
   location: StoreLocation;
   photos: string[]; // display_order 정렬된 URL 배열
   created_at: string;

--- a/src/lib/types/storeInsert.ts
+++ b/src/lib/types/storeInsert.ts
@@ -19,6 +19,7 @@ export interface StoreRow {
   event_post_url?: string;
   main_image_url?: string;
   logo_url: string | null; // 매장 로고 (nullable)
+  logo_thumb_url: string | null;
   is_visible: boolean;
   created_at: string;
   updated_at: string;

--- a/src/lib/utils/imageCompression.ts
+++ b/src/lib/utils/imageCompression.ts
@@ -50,3 +50,53 @@ export async function compressImageFile(file: File): Promise<File> {
     throw error;
   }
 }
+
+export async function generateThumbnail(
+  file: File,
+  maxSize = 256
+): Promise<File> {
+  try {
+    const options = {
+      maxSizeMB: 0.1,
+      maxWidthOrHeight: maxSize,
+      useWebWorker: true,
+      fileType: "image/webp",
+      initialQuality: 0.7,
+    };
+
+    const thumbnailBlob = await imageCompression(file, options);
+
+    const baseName = file.name.replace(/\.[^/.]+$/, "");
+    const thumbnailName = `${baseName}_thumb.webp`;
+
+    logger.error(
+      logger.createError(ErrorCode.FILE_COMPRESSED, {
+        metadata: {
+          originalSize: `${(file.size / 1024 / 1024).toFixed(2)}MB`,
+          thumbnailSize: `${(thumbnailBlob.size / 1024 / 1024).toFixed(2)}MB`,
+          maxSize,
+          purpose: "thumbnail",
+        },
+      })
+    );
+
+    return new File([thumbnailBlob], thumbnailName, {
+      type: "image/webp",
+      lastModified: file.lastModified,
+    });
+  } catch (error) {
+    logger.error(
+      logger.createError(ErrorCode.COMPRESSION_FAILED, {
+        originalError: error,
+        metadata: {
+          fileName: file.name,
+          fileSize: file.size,
+          fileType: file.type,
+          purpose: "thumbnail",
+          maxSize,
+        },
+      })
+    );
+    throw error;
+  }
+}


### PR DESCRIPTION
## Summary

Vercel Hobby 무료 한도(5,000 Image Optimization Transformations/월)를 100% 소진한 메일에서 출발해, 비용 절감 + 실브라우저 감사로 발견한 UI 버그를 함께 정리했습니다.

### 이미지 비용 절감 (구조적)
- `next.config.mjs` — `deviceSizes`/`imageSizes` 축소, `minimumCacheTTL` 31일
- 4개 리스트 컴포넌트(`CrewList`, `VisibleCrewList`, `RegionCrewRow`, `StoreCard`)에 `unoptimized` + `logo_thumb_url ?? logo_image` fallback
- `crews` / `stores` 테이블에 `logo_thumb_url` 컬럼 추가 (마이그레이션 SQL)
- 업로드 파이프라인 자동 썸네일: `generateThumbnail(file, 256)` → WebP, 동일 버킷에 `_thumb.webp` suffix 업로드
- 기존 로고 일괄 변환 스크립트(`scripts/backfill-logo-thumbs.ts`, sharp 사용)

### UI 정합성 (실브라우저 감사)
- **/menu**: 고정 높이로 9개 항목 잘리던 문제 → `min-h-screen` + nav padding
- **/store**: 페이지 제목이 헤더에 가려지던 문제 → `HEADER_PADDING` 적용
- **매장 상세 Sheet**: 데스크탑에서 풀폭으로 펼쳐지던 문제 → 크루 상세와 **동일 트랜지션**(`rounded-t-[10px]` + `md:430px` 카드)으로 통일
- **PWA 설치 배너**: 데스크탑에서 사이드 패널 영역으로 벗어나던 문제 → `DesktopSidePanel`과 동일 좌표 계산법으로 모바일 카드 위에 정렬

### 기능 추가
- 매장 사진 라이트박스(`StoreDetailView`)
  - 그리드 클릭 → 풀스크린 확대(`object-contain`, ≤90vw × 80vh)
  - 좌/우 화살표 + 카운터 `N / M`, X 닫기
  - 키보드: `Esc` 닫기 / `←` `→` 이동
  - 라이트박스 동안 배경 스크롤 잠금

### 타입/관련 변경
- 4개 타입 파일(`crew`, `crewInsert`, `store`, `storeInsert`)에 `logo_thumb_url` 필드 추가
- `admin/crew/edit/[id]/page.tsx` — `uploadCrewLogo` 반환 타입 변경(`string → { logo_image, logo_thumb_url }`)에 따른 caller 갱신

## ⚠️ 머지 후 액션 (순서 중요)

1. **Supabase SQL 에디터**에서 마이그레이션 적용
   ```sql
   -- migrations/2026-06-12-add-logo-thumb-url.sql
   ```
2. `npm install` — package-lock.json 재정렬 (sharp/tsx 신규, @supabase/supabase-js 위치 보정)
3. (선택) 기존 로고 일괄 백필
   ```bash
   SUPABASE_URL=... SUPABASE_SERVICE_ROLE_KEY=... npx tsx scripts/backfill-logo-thumbs.ts
   ```
4. 새 로고 업로드 1회 테스트 — `crews`/`stores` row에 `logo_thumb_url`이 채워지는지 확인

## 예상 효과
- 리스트 화면 로딩 이미지가 ~1MB → ~5–10KB
- `next/image` Transformations 호출 → 사실상 0에 수렴
- 다음 청구주기부터 무료 한도(5K/월) 내에서 운영 안정화

## Test plan
- [ ] `/menu` — 9개 항목 모두 접근 가능, MobileNav 미가림
- [ ] `/store` — 제목·매장 등록 CTA가 헤더에 가리지 않음
- [ ] `/store` 상세 클릭 — 크루 상세와 동일하게 시트 떠오름, 데스크탑에서 모바일 카드 위 정중앙
- [ ] `/store` 상세 PHOTOS 탭에서 사진 클릭 — 라이트박스 열림, 좌우 네비/Esc 동작
- [ ] `/map` 매장 마커 클릭 — 같은 시트 트랜지션
- [ ] 데스크탑(≥768px)에서 PWA 설치 배너 — 모바일 카드 안에 정렬
- [ ] 신규 로고 업로드 → DB의 `logo_thumb_url`에 `_thumb.webp` URL 채워짐
- [ ] `npx tsc --noEmit` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)