### PR TITLE
feat(admin): 관리자에서 사용자 사이트로 이탈 경로 추가

### DIFF
--- a/src/app/api/admin/logout/route.ts
+++ b/src/app/api/admin/logout/route.ts
@@ -1,11 +1,13 @@
 import { NextResponse } from "next/server";
 
-// 로그아웃: 인증 쿠키를 지우고 로그인 페이지로 리다이렉트.
+// 로그아웃: 인증 쿠키를 지우고 사용자 홈으로 리다이렉트.
 // 폼(POST)으로 호출되므로 JSON이 아니라 303 redirect를 돌려줘야
 // 사용자가 빈 JSON 화면에 멈추지 않는다. 쿠키 삭제(Set-Cookie)는
 // 반드시 이 redirect 응답에 직접 실어야 적용된다.
+// 로그인 페이지로 돌아가면 어디로 가야 할지 막막해지므로 공개 홈("/")으로 보낸다.
+// 다시 관리자로 가려면 /menu → 관리자.
 export async function POST(request: Request) {
-  const response = NextResponse.redirect(new URL("/admin/login", request.url), {
+  const response = NextResponse.redirect(new URL("/", request.url), {
     status: 303,
   });
   response.cookies.delete("auth");

--- a/src/components/layout/AdminBottomNav.tsx
+++ b/src/components/layout/AdminBottomNav.tsx
@@ -13,7 +13,7 @@ import { usePathname } from "next/navigation";
 import Link from "next/link";
 import { cn } from "@/lib/utils";
 import { LAYOUT } from "@/lib/constants";
-import { LayoutDashboard, Users, CalendarDays, LogOut } from "lucide-react";
+import { LayoutDashboard, Users, CalendarDays, LogOut, Home } from "lucide-react";
 
 interface NavItem {
   href: string;
@@ -95,6 +95,24 @@ export function AdminBottomNav() {
             </Link>
           );
         })}
+
+        {/* 사이트로 나가기 — 로그인 상태 유지, 일반 사용자 앱으로 이동.
+            관리자 작업 끝났지만 로그아웃은 안 하고 싶을 때. */}
+        <Link
+          href='/'
+          className={cn(
+            "flex flex-col items-center justify-center gap-1",
+            "transition-all duration-200 ease-out",
+            "px-4 py-2 rounded-[4px]",
+            "active:scale-[0.92] text-cart-ink-40 hover:text-[hsl(var(--lime))]"
+          )}
+          aria-label='사이트로 가기'
+        >
+          <Home className='w-[22px] h-[22px]' strokeWidth={1.6} />
+          <span className='font-mono text-[9px] tracking-[0.15em] uppercase font-semibold'>
+            사이트
+          </span>
+        </Link>
 
         {/* Logout — POST form clears the auth cookie via /api/admin/logout */}
         <form action='/api/admin/logout' method='POST' className='flex'>


### PR DESCRIPTION
## Summary

PR #17의 후속 — 관리자 UX 보완.

### 문제
- 관리자 로그아웃이 `/admin/login`으로 보내서 사용자가 다음 행동을 찾기 어려움
- 로그인 상태로 관리자 작업 끝낸 뒤 사용자 앱(`/`)으로 갈 길이 없음

### 변경
- 로그아웃 redirect: `/admin/login` → `/` (공개 홈)
- `AdminBottomNav`에 **"사이트"** 링크(Home 아이콘) 추가 — 로그인 유지하며 사용자 앱으로 이동, 복귀는 `/menu` → 관리자

### 사용 시나리오
| 동작 | 결과 |
|---|---|
| nav "사이트" 클릭 | 로그인 유지, `/`로 이동 |
| nav "로그아웃" 클릭 | 쿠키 삭제 + `/`로 이동 |
| 재진입 | `/menu` → "관리자" |

## Test plan
- [ ] `/admin` 접속 후 nav 5개 항목(대시보드/크루/이벤트/사이트/로그아웃) 모두 표시
- [ ] "사이트" 클릭 → `/` 이동, 다시 `/menu`에서 관리자 진입 가능 (쿠키 유지)
- [ ] "로그아웃" 클릭 → 쿠키 삭제 + `/` 이동

🤖 Generated with [Claude Code](https://claude.com/claude-code)