### PR TITLE
fix(register): PIN 입력 가시성 토글 + 분실 안내 인스타 핸들 정정

### DIFF
--- a/src/app/crew/edit/forgot/page.tsx
+++ b/src/app/crew/edit/forgot/page.tsx
@@ -13,12 +13,12 @@ export default function ForgotPinPage() {
         <p className="text-[12px] text-cart-ink-60 leading-relaxed mb-5">
           인스타그램{" "}
           <a
-            href="https://instagram.com/runhouse"
+            href="https://www.instagram.com/run_house_club/"
             target="_blank"
             rel="noreferrer"
             className="underline underline-offset-2"
           >
-            @runhouse
+            @run_house_club
           </a>
           로 크루명과 함께 &quot;PIN 초기화 요청&quot; 메시지를 보내주세요.
           admin이 확인 후 재설정 링크를 보내드립니다.

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -7,7 +7,7 @@ import posthog from "posthog-js";
 import { crewService } from "@/lib/services/crew.service";
 import { AppError, ErrorCode } from "@/lib/types/error";
 import { ResultDialog } from "@/components/dialog/ResultDialog";
-import { X, Upload } from "lucide-react";
+import { X, Upload, Eye, EyeOff } from "lucide-react";
 import MImage from "next/image";
 import { notifyCrewRegistration } from "@/app/actions/crew";
 import { KickerLabel } from "@/components/design/cartographic";
@@ -240,6 +240,8 @@ export default function RegisterPage() {
   const [pin, setPin] = useState("");
   const [pinConfirm, setPinConfirm] = useState("");
   const [pinError, setPinError] = useState<string | null>(null);
+  const [showPin, setShowPin] = useState(false);
+  const [showPinConfirm, setShowPinConfirm] = useState(false);
   const [foundedDate, setFoundedDate] = useState(todayDate);
   const [mainAddress, setMainAddress] = useState("");
 
@@ -1403,36 +1405,60 @@ export default function RegisterPage() {
               수정/관리에 사용할 <span className="font-semibold text-cart-ink">8자리</span> 비밀번호입니다. 잊지 않게 안전한 곳에 메모해두세요.
             </p>
             <div className='grid grid-cols-2 gap-3'>
-              <input
-                type='password'
-                inputMode='numeric'
-                pattern='[0-9]*'
-                maxLength={8}
-                placeholder='8자리 숫자'
-                value={pin}
-                onChange={(e) => {
-                  const v = e.target.value.replace(/\D/g, "").slice(0, 8);
-                  setPin(v);
-                  setPinError(null);
-                }}
-                disabled={isLoading}
-                className='font-mono text-[16px] tracking-[0.4em] text-center bg-cart-paper border border-cart-rule rounded-[4px] px-3 py-2.5'
-              />
-              <input
-                type='password'
-                inputMode='numeric'
-                pattern='[0-9]*'
-                maxLength={8}
-                placeholder='다시 입력'
-                value={pinConfirm}
-                onChange={(e) => {
-                  const v = e.target.value.replace(/\D/g, "").slice(0, 8);
-                  setPinConfirm(v);
-                  setPinError(null);
-                }}
-                disabled={isLoading}
-                className='font-mono text-[16px] tracking-[0.4em] text-center bg-cart-paper border border-cart-rule rounded-[4px] px-3 py-2.5'
-              />
+              <div className='relative'>
+                <input
+                  type={showPin ? 'text' : 'password'}
+                  inputMode='numeric'
+                  pattern='[0-9]*'
+                  maxLength={8}
+                  placeholder='8자리 숫자'
+                  value={pin}
+                  onChange={(e) => {
+                    const v = e.target.value.replace(/\D/g, "").slice(0, 8);
+                    setPin(v);
+                    setPinError(null);
+                  }}
+                  disabled={isLoading}
+                  aria-label='수정 PIN'
+                  className='w-full font-mono text-[16px] tracking-[0.4em] text-center bg-cart-paper border border-cart-rule rounded-[4px] pl-3 pr-10 py-2.5'
+                />
+                <button
+                  type='button'
+                  onClick={() => setShowPin((v) => !v)}
+                  disabled={isLoading}
+                  aria-label={showPin ? 'PIN 숨기기' : 'PIN 표시'}
+                  className='absolute right-2 top-1/2 -translate-y-1/2 p-1.5 rounded-[4px] text-cart-ink-60 hover:text-cart-ink hover:bg-white/[0.04] active:scale-95 transition-all'
+                >
+                  {showPin ? <EyeOff className='w-4 h-4' /> : <Eye className='w-4 h-4' />}
+                </button>
+              </div>
+              <div className='relative'>
+                <input
+                  type={showPinConfirm ? 'text' : 'password'}
+                  inputMode='numeric'
+                  pattern='[0-9]*'
+                  maxLength={8}
+                  placeholder='다시 입력'
+                  value={pinConfirm}
+                  onChange={(e) => {
+                    const v = e.target.value.replace(/\D/g, "").slice(0, 8);
+                    setPinConfirm(v);
+                    setPinError(null);
+                  }}
+                  disabled={isLoading}
+                  aria-label='수정 PIN 확인'
+                  className='w-full font-mono text-[16px] tracking-[0.4em] text-center bg-cart-paper border border-cart-rule rounded-[4px] pl-3 pr-10 py-2.5'
+                />
+                <button
+                  type='button'
+                  onClick={() => setShowPinConfirm((v) => !v)}
+                  disabled={isLoading}
+                  aria-label={showPinConfirm ? 'PIN 숨기기' : 'PIN 표시'}
+                  className='absolute right-2 top-1/2 -translate-y-1/2 p-1.5 rounded-[4px] text-cart-ink-60 hover:text-cart-ink hover:bg-white/[0.04] active:scale-95 transition-all'
+                >
+                  {showPinConfirm ? <EyeOff className='w-4 h-4' /> : <Eye className='w-4 h-4' />}
+                </button>
+              </div>
             </div>
             {pinError && (
               <p className='text-[11px] text-red-400 mt-1'>{pinError}</p>


### PR DESCRIPTION
## Summary

### 1. 크루 등록(`/register`) 수정 PIN 입력 가시성 토글
- 두 칸(PIN / PIN 확인)에 각각 눈 아이콘(Eye/EyeOff) 토글 추가
- `type` 동적 전환 (`password ↔ text`)
- 기존 검증 로직(`inputMode='numeric'`, 8자리, 숫자만) 그대로 유지
- 접근성: `aria-label` 적용

### 2. PIN 분실 안내(`/crew/edit/forgot`) 인스타 핸들 정정
- 기존 잘못된 링크: `instagram.com/runhouse` / `@runhouse`
- 정정: [`www.instagram.com/run_house_club`](https://www.instagram.com/run_house_club/) / `@run_house_club`

## Test plan
- [ ] `/register` 수정 PIN 칸에 입력 후 눈 아이콘 클릭 → 평문 표시
- [ ] 다시 클릭 → 마스킹 복귀, 각 칸 독립 동작
- [ ] 8자리 검증·숫자만 입력 기존처럼 동작
- [ ] `/crew/edit/forgot` — `@run_house_club` 표시, 클릭 시 올바른 인스타 프로필 새 탭

## 참고 (이번 PR에선 변경 안 함)
- `/crew/edit/login`, `/sso/authorize`의 인스타 입력 placeholder가 `@runhouse_official`인데, 이건 사용자가 자기 크루 핸들 입력하는 칸의 example이라 동작상 문제는 아닙니다. 다만 혼동 우려가 있으면 후속으로 `@your_crew_handle` 같은 일반 예시로 바꾸는 것도 고려 가능.

🤖 Generated with [Claude Code](https://claude.com/claude-code)