### PR TITLE
fix(auth): 로그인/PIN분실 페이지에 홈 이탈 경로 추가

### DIFF
--- a/src/app/crew/edit/forgot/page.tsx
+++ b/src/app/crew/edit/forgot/page.tsx
@@ -29,6 +29,12 @@ export default function ForgotPinPage() {
         >
           로그인으로 돌아가기
         </Link>
+        <Link
+          href="/"
+          className="block text-center w-full mt-2 py-2.5 rounded-[4px] text-cart-ink-60 hover:text-cart-ink font-mono text-[11px] tracking-[0.18em] uppercase font-semibold"
+        >
+          홈으로
+        </Link>
       </div>
     </div>
   );

--- a/src/app/crew/edit/login/LoginForm.tsx
+++ b/src/app/crew/edit/login/LoginForm.tsx
@@ -99,6 +99,13 @@ export default function LoginForm() {
             PIN을 잊으셨나요?
           </Link>
         </div>
+
+        <Link
+          href="/"
+          className="block text-center w-full mt-4 py-2.5 rounded-[4px] border border-cart-rule bg-background text-cart-ink-60 hover:text-cart-ink font-mono text-[11px] tracking-[0.18em] uppercase font-semibold"
+        >
+          홈으로
+        </Link>
       </form>
     </div>
   );

--- a/src/app/store/edit/login/LoginForm.tsx
+++ b/src/app/store/edit/login/LoginForm.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
+import Link from "next/link";
 import { loginStoreWithPin } from "@/app/actions/store";
 
 export default function LoginForm() {
@@ -81,6 +82,13 @@ export default function LoginForm() {
         >
           {isPending ? "로그인 중…" : "로그인"}
         </button>
+
+        <Link
+          href="/"
+          className="block text-center w-full mt-4 py-2.5 rounded-[4px] border border-cart-rule bg-background text-cart-ink-60 hover:text-cart-ink font-mono text-[11px] tracking-[0.18em] uppercase font-semibold"
+        >
+          홈으로
+        </Link>
       </form>
     </div>
   );


### PR DESCRIPTION
## Summary

크루·매장 로그인 및 PIN 분실 페이지에서 사용자가 흐름을 포기할 때 갈 곳이 없어 트랩됐던 문제 해결.

### 문제
이들 페이지는 user-facing `MobileNav`이 숨겨져 있어, 일단 들어오면 브라우저 뒤로가기 외엔 빠져나갈 길이 없었음:
- `/crew/edit/login` — 로그인 / PIN 잊음 외 선택지 없음
- `/store/edit/login` — 로그인 버튼만 (forgot 링크도 부재)
- `/crew/edit/forgot` — "로그인으로 돌아가기"만, 흐름 자체 포기 시 진로 없음

### 변경
세 곳 모두에 **"홈으로"** 보조 버튼 추가 (`href="/"`).
스타일:
- 로그인 페이지: hairline border 박스 (primary 로그인 버튼과 시각 구분)
- forgot 페이지: 텍스트 링크 (이미 있는 "로그인으로 돌아가기" 아래에 종속)

### 의도적으로 제외
- `/crew/edit/[id]` 자체 수정 페이지: 이미 "지도로 돌아가기" + ArrowLeft 보유
- `/sso/authorize`: OAuth 외부 앱 복귀 흐름, 홈 이탈 부적합

## Test plan
- [ ] `/crew/edit/login` 접속 → "홈으로" 클릭 → `/` 이동
- [ ] `/store/edit/login` 접속 → "홈으로" 클릭 → `/` 이동
- [ ] `/crew/edit/forgot` 접속 → "홈으로" 클릭 → `/` 이동
- [ ] 기존 "로그인" / "PIN을 잊으셨나요?" / "로그인으로 돌아가기" 동작 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)