### PR TITLE
hotfix: Vercel Image Optimization 비활성화 (402 응급)

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -38,6 +38,12 @@ const nextConfig = {
     },
   },
   images: {
+    // Vercel Image Optimization 전체 비활성화 — Hobby 무료 한도(5K Transformations/월)
+    // 초과로 402 Payment Required가 발생해 이미지 로드 자체가 실패하던 사고 대응.
+    // 모든 next/image 요청은 원본 URL로 직접 서비스(Supabase 등 자체 CDN 통과).
+    // 업로드 파이프라인에서 이미 webp 변환 + 256px 썸네일 사전 생성을 마쳤으므로
+    // 런타임 변환 의존성이 없다. Pro 플랜 전환 시 unoptimized:false로 복귀 가능.
+    unoptimized: true,
     formats: ["image/avif", "image/webp"],
     remotePatterns: [
       {


### PR DESCRIPTION
## 🚨 응급 핫픽스

### 증상
프로덕션 `runhouse.club`에서 `/_next/image` 요청이 **402 Payment Required**로 실패. Hobby 무료 한도(5K Transformations/월) 소진.

예시:
\`\`\`
GET /_next/image?url=...crewLogos/91b036fc...webp&w=128&q=20
→ 402 Payment Required
\`\`\`

### 조치
- `next.config.mjs`에 \`images.unoptimized: true\` 추가
- 모든 `next/image`는 원본 URL로 직접 서비스(Supabase CDN 등)
- 이전 PR(#17)에서 업로드 파이프라인이 이미 WebP 변환 + 256px 썸네일 사전 생성을 처리하므로 런타임 변환 의존성 없음

### 복귀 계획
- 다음 청구주기 시작 시 또는 Pro 플랜 전환 시 `unoptimized: false`로 복귀 가능
- `deviceSizes` / `imageSizes` / `minimumCacheTTL` 설정은 그대로 살아있어 복귀 즉시 동작

## Test plan (배포 후)
- [ ] 홈/리스트/지도/매장 화면 모두 이미지 정상 표시
- [ ] 콘솔/네트워크에 402 없음
- [ ] Vercel 대시보드의 Image Optimization 사용량 증가 멈춤