### PR TITLE
hotfix(map): 지도 마커도 Vercel Image Optimization 우회

### DIFF
--- a/src/components/map/NaverMap.tsx
+++ b/src/components/map/NaverMap.tsx
@@ -11,11 +11,12 @@ import { ListFilter, Target, Loader2, Plus } from "lucide-react";
 import Link from "next/link";
 import { crewService } from "@/lib/services/crew.service";
 
-// /_next/image 최적화 헬퍼 — 마커 HTML 문자열(raw <img>)에서 사용.
-// Supabase 원본 URL(~1MB)을 Next.js Image Optimization 엔드포인트로 우회하여
-// 브라우저가 64px 크기의 최적화된 이미지(~3–5KB)를 한 번만 받도록 한다.
-const markerImg = (url: string, w = 64) =>
-  `/_next/image?url=${encodeURIComponent(url)}&w=${w}&q=75`;
+// 마커 이미지 URL — 이전에는 /_next/image로 우회해 64px로 축소했지만, Vercel
+// Image Optimization 무료 한도 초과(402)로 사용 중단. 대신 호출처에서
+// logo_thumb_url(업로드 시 사전 생성된 256px WebP 썸네일)을 우선 넘기게 했고,
+// 없으면 원본 URL이 그대로 들어와 그래도 동작하도록 한다(체감 비용 ↑, 실패 X).
+// 시그니처는 호환성 위해 유지하되 w 인자는 의미 없음.
+const markerImg = (url: string, _w = 64) => url;
 
 // 매장 카테고리별 마커 색 — 디자인 톤 매핑 (계획서 Step 3).
 const STORE_COLOR: Record<StoreCategory, string> = {
@@ -382,11 +383,13 @@ export default function NaverMap({
         .slice(0, 10); // 화면에 보이는 이미지 중 최대 10개만 즉시 로드
 
       // 화면 내 크루 이미지 즉시 로드 — markerImg()와 동일한 URL을 사용하여
-      // 브라우저 캐시를 공유하고 원본 1MB 대신 최적화된 ~3-5KB를 받는다.
+      // 브라우저 캐시를 공유한다. logo_thumb_url(256px 사전 생성 썸네일)이 있으면
+      // 그것을, 없으면 원본을 사용해 실패 없이 동작.
       priorityCrews.forEach((crew) => {
-        if (crew.logo_image && !imageCache.current[crew.id]) {
+        const src = crew.logo_thumb_url ?? crew.logo_image;
+        if (src && !imageCache.current[crew.id]) {
           const img = new Image();
-          img.src = markerImg(crew.logo_image);
+          img.src = markerImg(src);
           img.decoding = "async";
           imageCache.current[crew.id] = img;
         }
@@ -399,9 +402,10 @@ export default function NaverMap({
           .slice(0, 20); // 최대 20개만 추가 로드
 
         remainingCrews.forEach((crew) => {
-          if (crew.logo_image) {
+          const src = crew.logo_thumb_url ?? crew.logo_image;
+          if (src) {
             const img = new Image();
-            img.src = markerImg(crew.logo_image);
+            img.src = markerImg(src);
             img.decoding = "async";
             img.loading = "lazy";
             imageCache.current[crew.id] = img;
@@ -484,10 +488,11 @@ export default function NaverMap({
 
     // Logo or initial inside the teardrop head
     let innerContent = "";
-    if (crew.logo_image) {
+    const crewLogoSrc = crew.logo_thumb_url ?? crew.logo_image;
+    if (crewLogoSrc) {
       innerContent = `
         <img
-          src="${markerImg(crew.logo_image)}"
+          src="${markerImg(crewLogoSrc)}"
           width="${logoSize}"
           height="${logoSize}"
           alt="${crew.name}"
@@ -542,8 +547,8 @@ export default function NaverMap({
     const logoSize = 32;
     const wellSize = logoSize + 2;
 
-    // 마커 이미지: 매장 로고(logo_url) 우선, 없으면 대표 사진(main_image_url)을 원형으로.
-    const markerUrl = store.logo_url || store.main_image_url;
+    // 마커 이미지: logo_thumb_url(256px 사전 썸네일) → logo_url → 대표 사진(main_image_url).
+    const markerUrl = store.logo_thumb_url || store.logo_url || store.main_image_url;
 
     let innerContent = "";
     if (markerUrl) {


### PR DESCRIPTION
## 🚨 핫픽스 #2 (PR #21 후속)

### 증상
- `/map` 의 크루/매장 마커 이미지가 **404**로 실패 (이전엔 402)
- 마커가 빈 도형 / 알파벳 fallback으로 표시

### 원인
PR #21에서 `next.config.mjs.images.unoptimized: true`로 전역 비활성화 했지만, **`next/image` React 컴포넌트에만 적용**되는 설정. NaverMap의 마커는 raw `<img>` 문자열을 직접 만들어 src에 `/_next/image?url=...&w=64` 같은 URL을 수동으로 박는 구조라 이 설정이 통하지 않음 (커밋 `576bfc9` 이력 참조).

```ts
// 기존
const markerImg = (url, w = 64) =>
  `/_next/image?url=${encodeURIComponent(url)}&w=${w}&q=75`;
```

### 조치
1. `markerImg` → 원본 URL 그대로 반환 (Vercel 우회)
2. 호출처에서 사전 생성된 256px 썸네일을 우선 사용:
   - 크루: `crew.logo_thumb_url ?? crew.logo_image`
   - 매장: `store.logo_thumb_url ?? store.logo_url ?? store.main_image_url`

### 부수효과
- **신규 업로드** (PR #17 이후): `_thumb.webp`(~5-10KB) 자동 사용 → 비용 동일, 성능 동일
- **기존 데이터** (backfill 미실행): 원본 ~1MB를 그대로 로드 → 비용 0, 모바일 데이터 ↑
- 권장: `scripts/backfill-logo-thumbs.ts` 한 번 실행하면 전 마커 정상화

### Test plan
- [ ] `runhouse.club/map` 강력 새로고침 (`Cmd+Shift+R`)
- [ ] 네트워크 탭에서 `_next/image` 요청 0건
- [ ] 마커 로고가 실제로 표시됨 (404 → 정상)
- [ ] 콘솔 에러 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)